### PR TITLE
docs: add logo and sage brand theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@ logs
 node_modules
 temp
 .turbo
-.vitepress/cache
-.vitepress/dist
+**/.vitepress/cache
+**/.vitepress/dist
 packages/devframe/skills

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Devframe
+<p align="center">
+  <a href="https://devfra.me/" target="_blank" rel="noopener noreferrer">
+    <img src="https://raw.githubusercontent.com/devframes/devframe/main/docs/public/logo.svg" width="140" alt="Devframe" />
+  </a>
+</p>
+
+<h1 align="center">Devframe</h1>
 
 [![npm version][npm-version-src]][npm-version-href]
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
@@ -72,13 +78,13 @@ await createCli(devframe).parse()
 
 <!-- Badges -->
 
-[npm-version-src]: https://img.shields.io/npm/v/devframe?style=flat&colorA=080f12&colorB=1fa669
+[npm-version-src]: https://img.shields.io/npm/v/devframe?style=flat&colorA=080f12&colorB=517158
 [npm-version-href]: https://npmx.dev/package/devframe
-[npm-downloads-src]: https://img.shields.io/npm/dm/devframe?style=flat&colorA=080f12&colorB=1fa669
+[npm-downloads-src]: https://img.shields.io/npm/dm/devframe?style=flat&colorA=080f12&colorB=517158
 [npm-downloads-href]: https://npmx.dev/package/devframe
-[bundle-src]: https://img.shields.io/bundlephobia/minzip/devframe?style=flat&colorA=080f12&colorB=1fa669&label=minzip
+[bundle-src]: https://img.shields.io/bundlephobia/minzip/devframe?style=flat&colorA=080f12&colorB=517158&label=minzip
 [bundle-href]: https://bundlephobia.com/result?p=devframe
-[license-src]: https://img.shields.io/github/license/devframes/devframe.svg?style=flat&colorA=080f12&colorB=1fa669
+[license-src]: https://img.shields.io/github/license/devframes/devframe.svg?style=flat&colorA=080f12&colorB=517158
 [license-href]: https://github.com/devframes/devframe/blob/main/LICENSE.md
-[jsdocs-src]: https://img.shields.io/badge/jsdocs-reference-080f12?style=flat&colorA=080f12&colorB=1fa669
+[jsdocs-src]: https://img.shields.io/badge/jsdocs-reference-080f12?style=flat&colorA=080f12&colorB=517158
 [jsdocs-href]: https://www.jsdocs.io/package/devframe

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -58,7 +58,11 @@ export function devframeNav(prefix = ''): DefaultTheme.NavItemWithLink[] {
 export default withMermaid(defineConfig({
   title: 'Devframe',
   description: 'Framework-neutral foundation for building generic DevTools — RPC layer, hosts, and adapters.',
+  head: [
+    ['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo.svg' }],
+  ],
   themeConfig: {
+    logo: { light: '/logo.svg', dark: '/logo.svg' },
     nav: [
       { text: 'Guide', items: guideItems('') },
       { text: 'Error Reference', link: '/errors/' },

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,4 @@
+import DefaultTheme from 'vitepress/theme'
+import './style.css'
+
+export default DefaultTheme

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1,0 +1,30 @@
+:root {
+  --vp-c-brand-1: #517158;
+  --vp-c-brand-2: #486954;
+  --vp-c-brand-3: #3e5c4a;
+  --vp-c-brand-soft: rgba(81, 113, 88, 0.14);
+
+  --vp-button-brand-border: transparent;
+  --vp-button-brand-text: #ffffff;
+  --vp-button-brand-bg: #517158;
+  --vp-button-brand-hover-border: transparent;
+  --vp-button-brand-hover-text: #ffffff;
+  --vp-button-brand-hover-bg: #486954;
+  --vp-button-brand-active-border: transparent;
+  --vp-button-brand-active-text: #ffffff;
+  --vp-button-brand-active-bg: #3e5c4a;
+
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: linear-gradient(120deg, #adc77f, #517158);
+
+  --vp-local-search-highlight-bg: #517158;
+}
+
+.dark {
+  --vp-c-brand-1: #adc77f;
+  --vp-c-brand-2: #93b062;
+  --vp-c-brand-3: #7f9c4e;
+  --vp-c-brand-soft: rgba(173, 199, 127, 0.16);
+
+  --vp-local-search-highlight-bg: #adc77f;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,10 @@ hero:
   name: Devframe
   text: Framework-neutral foundation for DevTools
   tagline: One devframe definition. Seven adapters. RPC, hosts, shared state, and agent-native — independent of Vite and any UI framework.
+  image:
+    src: /logo.svg
+    alt: Devframe
+    width: 240
   actions:
     - theme: brand
       text: Get Started

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -1,0 +1,23 @@
+<svg width="500" height="500" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_8_208)">
+<path d="M238.464 40H66V236.007H104.577C220.688 236.007 232.79 158.437 232.79 121.733C232.79 108.867 243.38 108.867 243.38 121.733C251.318 236.701 356.35 245.457 365.527 246.223L365.542 246.224C374.619 246.981 382.561 251.521 365.542 254.548C253.592 264.765 243.758 364.282 243.38 375.634C243.002 386.986 235.438 399.851 232.79 375.634C222.957 274.603 144.289 257.954 104.577 257.954H66V460.772H238.464C358.356 460.772 452.152 371.472 452.152 251.521C452.152 131.571 356.465 40 238.464 40Z" fill="url(#paint0_radial_8_208)" shape-rendering="crispEdges"/>
+<path d="M238.464 40H66V236.007H104.577C220.688 236.007 232.79 158.437 232.79 121.733C232.79 108.867 243.38 108.867 243.38 121.733C251.318 236.701 356.35 245.457 365.527 246.223L365.542 246.224C374.619 246.981 382.561 251.521 365.542 254.548C253.592 264.765 243.758 364.282 243.38 375.634C243.002 386.986 235.438 399.851 232.79 375.634C222.957 274.603 144.289 257.954 104.577 257.954H66V460.772H238.464C358.356 460.772 452.152 371.472 452.152 251.521C452.152 131.571 356.465 40 238.464 40Z" stroke="#86997F" stroke-opacity="0.5" stroke-width="1.33156" shape-rendering="crispEdges"/>
+</g>
+<defs>
+<filter id="filter0_d_8_208" x="60.7404" y="39.3342" width="396.671" height="431.358" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4.66045"/>
+<feGaussianBlur stdDeviation="2.29694"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.25464 0 0 0 0 0.285175 0 0 0 0 0.243391 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_8_208"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_8_208" result="shape"/>
+</filter>
+<radialGradient id="paint0_radial_8_208" cx="0" cy="0" r="1" gradientTransform="matrix(399.011 555.102 -568.423 408.982 -11.6221 -34.9218)" gradientUnits="userSpaceOnUse">
+<stop stop-color="#ADC77F"/>
+<stop offset="0.71903" stop-color="#517158"/>
+<stop offset="1" stop-color="#486954"/>
+</radialGradient>
+</defs>
+</svg>


### PR DESCRIPTION
## Summary
- Surface the new `docs/public/logo.svg` in the README (centered header) and VitePress (navbar, home hero, favicon).
- Override VitePress brand tokens with the logo's sage palette — `#517158` in light mode, `#ADC77F` in dark — and recolor the shield.io badges to match.
- Widen `.gitignore` globs so `.vitepress/{cache,dist}` are ignored from any workspace location.

## Test plan
- [x] `pnpm -C docs docs:build` succeeds; no config or theme errors.
- [x] `pnpm typecheck` and `pnpm lint docs/.vitepress` pass.
- [ ] Visual check on `pnpm -C docs docs` — logo in navbar + hero, sage buttons, dark-mode flip.