### PR TITLE
fix(devframe): bundle agnostic ohash digest to keep node:crypto out of browser

### DIFF
--- a/packages/devframe/package.json
+++ b/packages/devframe/package.json
@@ -89,6 +89,7 @@
     "human-id": "catalog:inlined",
     "immer": "catalog:deps",
     "launch-editor": "catalog:deps",
+    "mlly": "catalog:build",
     "obug": "catalog:deps",
     "ohash": "catalog:deps",
     "open": "catalog:deps",
@@ -100,7 +101,7 @@
     "whenexpr": "catalog:deps"
   },
   "inlinedDependencies": {
-    "ansis": "4.2.0",
+    "ansis": "4.3.0",
     "bundle-name": "4.1.0",
     "default-browser": "5.5.0",
     "default-browser-id": "5.0.1",

--- a/packages/devframe/tsdown.config.ts
+++ b/packages/devframe/tsdown.config.ts
@@ -1,6 +1,19 @@
+import { fileURLToPath } from 'node:url'
+import { resolveSync } from 'mlly'
 import { defineConfig } from 'tsdown'
 
+// Resolve `ohash/crypto` without the `node` condition so the pure-JS digest
+// is bundled. The default resolution honours `node`, which inlines
+// `node:crypto.createHash` into outputs that are later shipped to the
+// browser via the `client` entry.
+const ohashCryptoAgnostic = fileURLToPath(
+  resolveSync('ohash/crypto', { url: import.meta.url, conditions: ['import'] }),
+)
+
 export default defineConfig({
+  alias: {
+    'ohash/crypto': ohashCryptoAgnostic,
+  },
   entry: {
     'index': 'src/index.ts',
     'rpc/index': 'src/rpc/index.ts',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@preact/preset-vite':
       specifier: ^2.10.5
       version: 2.10.5
+    mlly:
+      specifier: ^1.8.2
+      version: 1.8.2
     tsdown:
       specifier: ^0.22.0
       version: 0.22.0
@@ -345,6 +348,9 @@ importers:
       launch-editor:
         specifier: catalog:deps
         version: 2.13.2
+      mlly:
+        specifier: catalog:build
+        version: 1.8.2
       obug:
         specifier: catalog:deps
         version: 2.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,7 @@ catalogs:
     '@antfu/ni': ^30.1.0
     '@nuxt/kit': ^4.4.5
     '@preact/preset-vite': ^2.10.5
+    mlly: ^1.8.2
     tsdown: ^0.22.0
     tsx: ^4.21.0
     turbo: ^2.9.12


### PR DESCRIPTION
## Summary

- `ohash`'s main entry imports `digest` from `ohash/crypto`, whose conditional exports pick `node` (which imports `node:crypto.createHash`) when bundled by tsdown. That digest was being inlined into `dist/utils/hash.mjs` and transitively re-exported through `dist/client/index.mjs` via `rpc/cache.ts`, so every browser consumer of `devframe/client` ended up with a `node:crypto` import — broken.
- Force the agnostic (pure-JS) variant by aliasing `ohash/crypto` to the path produced by `mlly.resolveSync` with `conditions: ['import']`, skipping the `node` branch only for this specifier (other deps keep normal resolution).
- Add `mlly` to the `build` catalog and to devframe's devDependencies so the build-time resolution is properly declared. No source change needed — the alias is transparent to `utils/hash.ts`.

## Test plan

- [x] `pnpm build` — `grep -RE "node:crypto|createHash" packages/devframe/dist/` returns no matches; bundled hash chunk now embeds `ohash/dist/crypto/js/index.mjs`.
- [x] `pnpm test` — 283 tests pass, snapshots in `dumps.test.ts.snap` unchanged (JS and Node digests are bit-identical for SHA-256 + base64url).
- [x] `pnpm lint` and `pnpm typecheck` clean.