### PR TITLE
chore: upgrade pnpm to v11

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Source layout:
 ## Development
 
 ```sh
-pnpm install      # requires pnpm@10.x
+pnpm install      # requires pnpm@11.x
 pnpm build        # tsdown
 pnpm dev          # tsdown --watch
 pnpm test         # pnpm build && vitest (api snapshot guards against stale dist)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.2.2",
   "private": true,
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.1.2",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",
   "funding": "https://github.com/sponsors/antfu",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 allowBuilds:
+  '@parcel/watcher': false
   esbuild: true
   simple-git-hooks: true
   unrs-resolver: true


### PR DESCRIPTION
## Summary

- Bump `packageManager` to `pnpm@11.1.2` (from `10.33.4`) and refresh the `pnpm@11.x` note in `AGENTS.md`.
- Pin `@parcel/watcher` to `false` under `allowBuilds`; pnpm 11 auto-detects it as a build-script candidate, and `false` preserves the prior pnpm 10 behaviour where the install script was implicitly ignored.
- No lockfile churn — existing `lockfileVersion: '9.0'` is already compatible, and the repo had nothing using `.npmrc`, the `pnpm` field in `package.json`, or `patchedDependencies`, so no v11 migrations were needed.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm test` (319/319 passing)