### PR TITLE
fix(hub): ship dist/ in published tarball

### DIFF
--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -34,7 +34,8 @@
   ],
   "scripts": {
     "build": "tsdown",
-    "watch": "tsdown --watch"
+    "watch": "tsdown --watch",
+    "prepack": "pnpm run build"
   },
   "peerDependencies": {
     "devframe": "workspace:*"


### PR DESCRIPTION
0.5.0 and 0.5.1 published empty tarballs (LICENSE.md + package.json only, 2.4 KB) because the package had no `prepack` hook to build `dist/` before npm ran, so consumers couldn't resolve any of the entry points in the exports map. This adds the same `pnpm run build` prepack that `@devframes/nuxt` already uses, so the next release ships the full `dist/` tree. Broken 0.5.0 and 0.5.1 will need `npm deprecate` after the follow-up release goes out.

This PR was created with the help of an agent.