### PR TITLE
feat(examples): add dock switcher UI to minimal hub examples

### DIFF
--- a/examples/minimal-next-devframe-hub/spa/next-demo-tool-b/index.html
+++ b/examples/minimal-next-devframe-hub/spa/next-demo-tool-b/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Next Demo Tool B</title>
+    <style>
+      :root { color-scheme: light dark; font-family: system-ui, sans-serif; }
+      body { margin: 0; padding: 2rem; }
+      h1 { margin-top: 0; }
+      code { font-family: ui-monospace, monospace; }
+    </style>
+  </head>
+  <body>
+    <h1>Next Demo Tool B</h1>
+    <p>Served from <code id="loc"></code></p>
+    <p>A second demo devframe, mounted alongside the first to demonstrate dock switching.</p>
+    <script>
+      document.getElementById('loc').textContent = location.pathname
+    </script>
+  </body>
+</html>

--- a/examples/minimal-next-devframe-hub/spa/next-demo-tool/index.html
+++ b/examples/minimal-next-devframe-hub/spa/next-demo-tool/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Next Demo Tool</title>
+    <style>
+      :root { color-scheme: light dark; font-family: system-ui, sans-serif; }
+      body { margin: 0; padding: 2rem; }
+      h1 { margin-top: 0; }
+      code { font-family: ui-monospace, monospace; }
+    </style>
+  </head>
+  <body>
+    <h1>Next Demo Tool</h1>
+    <p>Served from <code id="loc"></code></p>
+    <p>This SPA is mounted by <code>minimal-next-devframe-hub</code> via <code>DevframeHost.mountStatic()</code>.</p>
+    <script>
+      document.getElementById('loc').textContent = location.pathname
+    </script>
+  </body>
+</html>

--- a/examples/minimal-next-devframe-hub/src/client/app/%5F_[id]/[[...path]]/route.ts
+++ b/examples/minimal-next-devframe-hub/src/client/app/%5F_[id]/[[...path]]/route.ts
@@ -1,0 +1,103 @@
+import { createReadStream } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import { Readable } from 'node:stream'
+import { extname, join, normalize, resolve, sep } from 'pathe'
+import { ensureMinimalNextDevframeHub, getStaticMount } from '../../../devframe/minimal-next-devframe-hub'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.htm': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.mjs': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+}
+
+interface ResolvedFile {
+  abs: string
+  size: number
+  mtime: Date
+}
+
+async function statFile(abs: string): Promise<ResolvedFile | null> {
+  try {
+    const s = await stat(abs)
+    if (!s.isFile())
+      return null
+    return { abs, size: s.size, mtime: s.mtime }
+  }
+  catch {
+    return null
+  }
+}
+
+async function resolveTarget(absDir: string, urlPath: string): Promise<ResolvedFile | null> {
+  let cleaned = decodeURIComponent(urlPath || '/').replace(/[?#].*$/, '')
+  if (cleaned.endsWith('/'))
+    cleaned = cleaned.slice(0, -1)
+  if (cleaned.startsWith('/'))
+    cleaned = cleaned.slice(1)
+
+  const abs = normalize(join(absDir, cleaned))
+  if (abs !== absDir && !abs.startsWith(absDir + sep))
+    return null
+
+  const direct = await statFile(abs)
+  if (direct)
+    return direct
+
+  // Directory → index.html
+  try {
+    const s = await stat(abs)
+    if (s.isDirectory()) {
+      const candidate = await statFile(join(abs, 'index.html'))
+      if (candidate)
+        return candidate
+    }
+  }
+  catch {
+    // not found / not a directory — continue
+  }
+
+  // SPA fallback for extensionless paths
+  if (!/\.[a-z0-9]+$/i.test(cleaned)) {
+    const fallback = await statFile(join(absDir, 'index.html'))
+    if (fallback)
+      return fallback
+  }
+
+  return null
+}
+
+export async function GET(request: Request): Promise<Response> {
+  await ensureMinimalNextDevframeHub()
+
+  const pathname = new URL(request.url).pathname
+  const hit = getStaticMount(pathname)
+  if (!hit)
+    return new Response(null, { status: 404 })
+
+  const file = await resolveTarget(resolve(hit.distDir), hit.relative)
+  if (!file)
+    return new Response(null, { status: 404 })
+
+  return new Response(Readable.toWeb(createReadStream(file.abs)) as ReadableStream, {
+    status: 200,
+    headers: {
+      'Content-Type': CONTENT_TYPES[extname(file.abs).toLowerCase()] ?? 'application/octet-stream',
+      'Content-Length': String(file.size),
+      'Last-Modified': file.mtime.toUTCString(),
+      'Cache-Control': 'no-store',
+    },
+  })
+}

--- a/examples/minimal-next-devframe-hub/src/client/app/globals.css
+++ b/examples/minimal-next-devframe-hub/src/client/app/globals.css
@@ -6,48 +6,99 @@
 
 body {
   margin: 0;
-  padding: 1.5rem 2rem;
+  height: 100vh;
+  overflow: hidden;
 }
 
-main {
-  max-width: 800px;
-  margin-inline: auto;
+.app-shell {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas:
+    "header header"
+    "sidebar main"
+    "footer footer";
+  height: 100vh;
 }
 
-header h1 {
-  margin-bottom: 0.25rem;
+.app-header {
+  grid-area: header;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid color-mix(in srgb, currentcolor 20%, transparent);
 }
 
-header p {
-  margin-top: 0;
+.app-header h1 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.app-header p {
+  margin: 0.25rem 0 0;
+  font-family: ui-monospace, monospace;
+  font-size: 0.8rem;
   opacity: 0.7;
 }
 
-section {
-  margin-block: 1.5rem;
+.app-sidebar {
+  grid-area: sidebar;
+  border-right: 1px solid color-mix(in srgb, currentcolor 20%, transparent);
+  padding: 0.75rem;
+  overflow: auto;
+}
+
+.app-main {
+  grid-area: main;
+  overflow: hidden;
+  background: color-mix(in srgb, currentcolor 3%, transparent);
+}
+
+.app-main iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+}
+
+.app-footer {
+  grid-area: footer;
+  display: flex;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid color-mix(in srgb, currentcolor 20%, transparent);
+  max-height: 30vh;
+  overflow: auto;
+}
+
+.app-footer section {
+  flex: 1;
+  min-width: 0;
 }
 
 h2 {
-  font-size: 1rem;
+  font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   opacity: 0.8;
-  border-bottom: 1px solid currentcolor;
-  padding-bottom: 0.25rem;
+  margin: 0 0 0.5rem;
 }
 
 ul {
   list-style: none;
   padding-left: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 li {
-  padding: 0.5rem 0.75rem;
+  padding: 0.4rem 0.6rem;
   border: 1px solid color-mix(in srgb, currentcolor 15%, transparent);
-  border-radius: 0.5rem;
-  margin-bottom: 0.5rem;
+  border-radius: 0.4rem;
   font-family: ui-monospace, monospace;
-  font-size: 0.9rem;
+  font-size: 0.8rem;
 }
 
 li.muted {
@@ -62,29 +113,54 @@ code {
   border-radius: 0.25em;
 }
 
-button {
-  font: inherit;
-  padding: 0.5rem 1rem;
-  border-radius: 0.5rem;
-  border: 1px solid currentcolor;
+.app-sidebar ul li {
+  padding: 0;
+  border: 0;
   background: transparent;
-  cursor: pointer;
 }
 
-button:hover {
-  background: color-mix(in srgb, currentcolor 10%, transparent);
+.app-sidebar button {
+  width: 100%;
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  font: inherit;
+  font-size: 0.85rem;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 0.4rem;
+  cursor: pointer;
+  color: inherit;
+}
+
+.app-sidebar button:hover {
+  background: color-mix(in srgb, currentcolor 8%, transparent);
+}
+
+.app-sidebar button.active {
+  background: color-mix(in srgb, currentcolor 15%, transparent);
+  border-color: color-mix(in srgb, currentcolor 30%, transparent);
 }
 
 .actions {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
+  align-items: flex-start;
 }
 
-#status {
-  font-family: ui-monospace, monospace;
+button {
+  font: inherit;
   font-size: 0.85rem;
-  opacity: 0.7;
+  padding: 0.4rem 0.8rem;
+  border-radius: 0.4rem;
+  border: 1px solid currentcolor;
+  background: transparent;
+  cursor: pointer;
+  color: inherit;
+}
+
+button:hover {
+  background: color-mix(in srgb, currentcolor 10%, transparent);
 }
 
 #status.error span {

--- a/examples/minimal-next-devframe-hub/src/client/app/page.tsx
+++ b/examples/minimal-next-devframe-hub/src/client/app/page.tsx
@@ -9,7 +9,7 @@ import type {
 } from '@devframes/hub/types'
 import type { ReactNode } from 'react'
 import { connectDevframe } from '@devframes/hub/client'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 const HUB_BASE = '/__hub/'
 
@@ -18,7 +18,12 @@ interface Status {
   kind?: 'ready' | 'error'
 }
 
+type IframeDock = DevframeDockEntry & { type: 'iframe', url: string }
 type TerminalSummary = Pick<DevframeTerminalSession, 'id' | 'title' | 'status' | 'description'>
+
+function isIframeDock(d: DevframeDockEntry): d is IframeDock {
+  return d.type === 'iframe' && typeof (d as { url?: unknown }).url === 'string'
+}
 
 export default function Page() {
   const [status, setStatus] = useState<Status>({ text: 'Connecting...' })
@@ -27,6 +32,7 @@ export default function Page() {
   const [messages, setMessages] = useState<DevframeMessageEntry[]>([])
   const [terminals, setTerminals] = useState<TerminalSummary[]>([])
   const [pingResult, setPingResult] = useState('Run ping')
+  const [selectedDockId, setSelectedDockId] = useState<string | null>(null)
   const rpcRef = useRef<DevframeRpcClient | null>(null)
 
   useEffect(() => {
@@ -99,6 +105,19 @@ export default function Page() {
     }
   }, [])
 
+  const iframeDocks = useMemo(() => docks.filter(isIframeDock), [docks])
+
+  useEffect(() => {
+    if (selectedDockId && !iframeDocks.some(d => d.id === selectedDockId)) {
+      setSelectedDockId(null)
+      return
+    }
+    if (!selectedDockId && iframeDocks.length > 0)
+      setSelectedDockId(iframeDocks[0].id)
+  }, [iframeDocks, selectedDockId])
+
+  const selectedDock = iframeDocks.find(d => d.id === selectedDockId) ?? null
+
   async function ping() {
     if (!rpcRef.current)
       return
@@ -115,73 +134,78 @@ export default function Page() {
   }
 
   return (
-    <main>
-      <header>
+    <div className="app-shell">
+      <header className="app-header">
         <h1>Minimal Next Devframe Hub</h1>
-        <p>
-          Protocol witness: verifies
-          {' '}
-          <code>@devframes/hub</code>
-          {' '}
-          end to end from a Next.js host.
+        <p id="status" className={status.kind ?? ''}>
+          <span>{status.text}</span>
         </p>
       </header>
 
-      <section id="status" className={status.kind ?? ''}>
-        <span>{status.text}</span>
-      </section>
+      <aside className="app-sidebar">
+        <h2>Docks</h2>
+        <ul>
+          {iframeDocks.length === 0
+            ? <li className="muted">No iframe docks</li>
+            : iframeDocks.map(dock => (
+                <li key={dock.id}>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedDockId(dock.id)}
+                    className={dock.id === selectedDockId ? 'active' : ''}
+                  >
+                    {dock.title}
+                  </button>
+                </li>
+              ))}
+        </ul>
+      </aside>
 
-      <Panel title="Docks" empty="Waiting for snapshot...">
-        {docks.map(dock => (
-          <li key={dock.id}>
-            <strong>{dock.title}</strong>
-            {' '}
-            <code>{dock.id}</code>
-            {'badge' in dock && dock.badge
-              ? <span className="badge">{`[${dock.badge}]`}</span>
-              : null}
-          </li>
-        ))}
-      </Panel>
+      <main className="app-main">
+        <iframe
+          key={selectedDock?.id ?? 'none'}
+          src={selectedDock?.url ?? 'about:blank'}
+          title="Selected dock"
+        />
+      </main>
 
-      <Panel title="Commands" empty="Waiting for snapshot...">
-        {commands.map(command => (
-          <li key={command.id}>
-            <strong>{command.title}</strong>
-            {' '}
-            <code>{command.id}</code>
-          </li>
-        ))}
-      </Panel>
-
-      <div className="actions">
-        <button type="button" onClick={() => void ping()}>
-          {pingResult}
-        </button>
-      </div>
-
-      <Panel title="Messages" empty="No messages yet.">
-        {messages.map(message => (
-          <li key={message.id}>
-            <strong>{`[${message.level}]`}</strong>
-            {' '}
-            {message.message}
-          </li>
-        ))}
-      </Panel>
-
-      <Panel title="Terminals" empty="No terminal sessions.">
-        {terminals.map(terminal => (
-          <li key={terminal.id}>
-            <strong>{terminal.title}</strong>
-            {' '}
-            <code>{terminal.id}</code>
-            {' '}
-            {terminal.status}
-          </li>
-        ))}
-      </Panel>
-    </main>
+      <footer className="app-footer">
+        <Panel title="Commands" empty="Waiting for snapshot...">
+          {commands.map(command => (
+            <li key={command.id}>
+              <strong>{command.title}</strong>
+              {' '}
+              <code>{command.id}</code>
+            </li>
+          ))}
+        </Panel>
+        <Panel title="Messages" empty="No messages yet.">
+          {messages.map(message => (
+            <li key={message.id}>
+              <strong>{`[${message.level}]`}</strong>
+              {' '}
+              {message.message}
+            </li>
+          ))}
+        </Panel>
+        <Panel title="Terminals" empty="No terminal sessions.">
+          {terminals.map(terminal => (
+            <li key={terminal.id}>
+              <strong>{terminal.title}</strong>
+              {' '}
+              <code>{terminal.id}</code>
+              {' '}
+              {terminal.status}
+            </li>
+          ))}
+        </Panel>
+        <div className="actions">
+          <button type="button" onClick={() => void ping()}>
+            {pingResult}
+          </button>
+        </div>
+      </footer>
+    </div>
   )
 }
 

--- a/examples/minimal-next-devframe-hub/src/client/devframe/demo-devframe-b.ts
+++ b/examples/minimal-next-devframe-hub/src/client/devframe/demo-devframe-b.ts
@@ -6,28 +6,28 @@ import { dirname, resolve } from 'pathe'
 const HERE = dirname(fileURLToPath(import.meta.url))
 
 export default defineDevframe({
-  id: 'next-demo-tool',
-  name: 'Next Demo Tool',
-  icon: 'ph:rocket-duotone',
-  basePath: '/__next-demo-tool/',
+  id: 'next-demo-tool-b',
+  name: 'Next Demo Tool B',
+  icon: 'ph:wrench-duotone',
+  basePath: '/__next-demo-tool-b/',
   cli: {
-    distDir: resolve(HERE, '../../../spa/next-demo-tool'),
+    distDir: resolve(HERE, '../../../spa/next-demo-tool-b'),
   },
   async setup(rawCtx) {
     const ctx = rawCtx as unknown as DevframeHubContext
 
     ctx.commands.register({
-      id: 'next-demo-tool:say-hello',
-      title: 'Next Demo Tool: Say Hello',
+      id: 'next-demo-tool-b:say-hello',
+      title: 'Next Demo Tool B: Say Hello',
       icon: 'ph:hand-waving-duotone',
       category: 'demo',
-      handler: () => 'Hello from the Next demo command!',
+      handler: () => 'Hello from next-demo-tool-b!',
     })
 
     await ctx.messages.add({
       level: 'info',
-      message: 'Next demo devframe loaded',
-      description: 'Registered via mountDevframe() from the Next host.',
+      message: 'Second Next demo devframe loaded',
+      description: 'A second mountDevframe() call — proves the switcher has more than one option.',
     })
   },
 })

--- a/examples/minimal-next-devframe-hub/src/client/devframe/minimal-next-devframe-hub.ts
+++ b/examples/minimal-next-devframe-hub/src/client/devframe/minimal-next-devframe-hub.ts
@@ -9,6 +9,28 @@ import { startHttpAndWs } from 'devframe/node'
 import { getPort } from 'get-port-please'
 import { join } from 'pathe'
 import demoDevframe from './demo-devframe'
+import demoDevframeB from './demo-devframe-b'
+
+const STATIC_MOUNTS = new Map<string, string>()
+
+export interface StaticMountHit {
+  distDir: string
+  relative: string
+}
+
+export function getStaticMount(pathname: string): StaticMountHit | null {
+  let best: { base: string, distDir: string } | null = null
+  for (const [base, distDir] of STATIC_MOUNTS) {
+    if (pathname === base || pathname.startsWith(`${base}/`)) {
+      if (!best || base.length > best.base.length)
+        best = { base, distDir }
+    }
+  }
+  if (!best)
+    return null
+  const relative = pathname.slice(best.base.length) || '/'
+  return { distDir: best.distDir, relative }
+}
 
 export interface MinimalNextDevframeHubOptions {
   /** Preferred port for the side-car RPC/WS server. Default: a free port near 9877. */
@@ -60,9 +82,8 @@ export async function minimalNextDevframeHub(
   const hostName = options.host ?? 'localhost'
 
   const host: DevframeHost = {
-    mountStatic() {
-      // Static mounting for devframe SPAs would route through Next middleware
-      // in a fuller host. This minimal example keeps mounted devframes headless.
+    mountStatic(base, distDir) {
+      STATIC_MOUNTS.set(base.replace(/\/$/, ''), distDir)
     },
     resolveOrigin() {
       return `http://${hostName}:3000`
@@ -101,7 +122,7 @@ export async function minimalNextDevframeHub(
     description: `Side-car WS on port ${port}. ${options.devframes?.length ?? 1} devframe(s) registered.`,
   })
 
-  for (const def of options.devframes ?? [demoDevframe]) {
+  for (const def of options.devframes ?? [demoDevframe, demoDevframeB]) {
     await mountDevframe(context, def)
   }
 

--- a/examples/minimal-vite-devframe-hub/index.html
+++ b/examples/minimal-vite-devframe-hub/index.html
@@ -7,38 +7,41 @@
     <link rel="stylesheet" href="/src/client/style.css" />
   </head>
   <body>
-    <header>
-      <h1>Minimal Vite Devframe Hub</h1>
-      <p>Protocol witness — verifies <code>@devframes/hub</code> end to end.</p>
-    </header>
-    <main>
-      <section id="status">
-        <span id="conn">Connecting…</span>
-      </section>
+    <div class="app-shell">
+      <header class="app-header">
+        <h1>Minimal Vite Devframe Hub</h1>
+        <p id="status"><span id="conn">Connecting…</span></p>
+      </header>
 
-      <section>
+      <aside class="app-sidebar">
         <h2>Docks</h2>
         <ul id="docks"><li class="muted">Waiting for snapshot…</li></ul>
-      </section>
+      </aside>
 
-      <section>
-        <h2>Commands</h2>
-        <ul id="commands"><li class="muted">Waiting for snapshot…</li></ul>
-        <p>
-          <button id="ping">Dispatch <code>minimal-vite-devframe-hub:ping</code> via <code>hub:commands:execute</code></button>
-        </p>
-      </section>
+      <main class="app-main">
+        <iframe id="dock-iframe" src="about:blank" title="Selected dock"></iframe>
+      </main>
 
-      <section>
-        <h2>Messages</h2>
-        <ul id="messages"><li class="muted">No messages yet.</li></ul>
-      </section>
+      <footer class="app-footer">
+        <section>
+          <h2>Commands</h2>
+          <ul id="commands"><li class="muted">Waiting for snapshot…</li></ul>
+          <div class="actions">
+            <button id="ping">Dispatch <code>minimal-vite-devframe-hub:ping</code></button>
+          </div>
+        </section>
 
-      <section>
-        <h2>Terminals</h2>
-        <ul id="terminals"><li class="muted">No terminal sessions.</li></ul>
-      </section>
-    </main>
+        <section>
+          <h2>Messages</h2>
+          <ul id="messages"><li class="muted">No messages yet.</li></ul>
+        </section>
+
+        <section>
+          <h2>Terminals</h2>
+          <ul id="terminals"><li class="muted">No terminal sessions.</li></ul>
+        </section>
+      </footer>
+    </div>
     <script type="module" src="/src/client/main.ts"></script>
   </body>
 </html>

--- a/examples/minimal-vite-devframe-hub/spa/demo-tool-b/index.html
+++ b/examples/minimal-vite-devframe-hub/spa/demo-tool-b/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Demo Tool B</title>
+    <style>
+      :root { color-scheme: light dark; font-family: system-ui, sans-serif; }
+      body { margin: 0; padding: 2rem; }
+      h1 { margin-top: 0; }
+      code { font-family: ui-monospace, monospace; }
+    </style>
+  </head>
+  <body>
+    <h1>Demo Tool B</h1>
+    <p>Served from <code id="loc"></code></p>
+    <p>A second demo devframe, mounted alongside the first to demonstrate dock switching.</p>
+    <script>
+      document.getElementById('loc').textContent = location.pathname
+    </script>
+  </body>
+</html>

--- a/examples/minimal-vite-devframe-hub/spa/demo-tool/index.html
+++ b/examples/minimal-vite-devframe-hub/spa/demo-tool/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Demo Tool</title>
+    <style>
+      :root { color-scheme: light dark; font-family: system-ui, sans-serif; }
+      body { margin: 0; padding: 2rem; }
+      h1 { margin-top: 0; }
+      code { font-family: ui-monospace, monospace; }
+    </style>
+  </head>
+  <body>
+    <h1>Demo Tool</h1>
+    <p>Served from <code id="loc"></code></p>
+    <p>This SPA is mounted by <code>minimal-vite-devframe-hub</code> via <code>DevframeHost.mountStatic()</code>.</p>
+    <script>
+      document.getElementById('loc').textContent = location.pathname
+    </script>
+  </body>
+</html>

--- a/examples/minimal-vite-devframe-hub/src/client/main.ts
+++ b/examples/minimal-vite-devframe-hub/src/client/main.ts
@@ -15,6 +15,9 @@ const commandsEl = document.querySelector<HTMLElement>('#commands')!
 const messagesEl = document.querySelector<HTMLElement>('#messages')!
 const terminalsEl = document.querySelector<HTMLElement>('#terminals')!
 const pingBtn = document.querySelector<HTMLButtonElement>('#ping')!
+const iframeEl = document.querySelector<HTMLIFrameElement>('#dock-iframe')!
+
+let selectedDockId: string | null = null
 
 function setStatus(text: string, klass?: 'ready' | 'error') {
   connEl.textContent = text
@@ -29,6 +32,10 @@ function renderList<T>(host: HTMLElement, items: T[], render: (item: T) => strin
   host.innerHTML = items.map(render).join('')
 }
 
+function isIframeDock(d: DevframeDockEntry): d is DevframeDockEntry & { type: 'iframe', url: string } {
+  return d.type === 'iframe' && typeof (d as { url?: unknown }).url === 'string'
+}
+
 async function main() {
   setStatus('Connecting…')
 
@@ -40,10 +47,40 @@ async function main() {
     'devframe:docks',
     { initialValue: [] },
   )
-  const renderDocks = () => renderList(docksEl, docks.value() ?? [], (d) => {
-    const badge = d.badge ? ` <span class="badge">[${d.badge}]</span>` : ''
-    return `<li><strong>${d.title}</strong> <code>${d.id}</code>${badge}</li>`
+
+  const renderDocks = () => {
+    const iframeDocks = (docks.value() ?? []).filter(isIframeDock)
+
+    if (selectedDockId && !iframeDocks.some(d => d.id === selectedDockId))
+      selectedDockId = null
+    if (!selectedDockId && iframeDocks.length > 0)
+      selectedDockId = iframeDocks[0].id
+
+    if (!iframeDocks.length) {
+      docksEl.innerHTML = '<li class="muted">No iframe docks</li>'
+      iframeEl.src = 'about:blank'
+      return
+    }
+
+    renderList(docksEl, iframeDocks, d =>
+      `<li><button type="button" data-dock-id="${d.id}" class="${d.id === selectedDockId ? 'active' : ''}">${d.title}</button></li>`)
+
+    const selected = iframeDocks.find(d => d.id === selectedDockId)
+    if (selected && iframeEl.getAttribute('src') !== selected.url)
+      iframeEl.src = selected.url
+  }
+
+  docksEl.addEventListener('click', (event) => {
+    const target = (event.target as HTMLElement).closest<HTMLButtonElement>('button[data-dock-id]')
+    if (!target)
+      return
+    const id = target.dataset.dockId
+    if (!id || id === selectedDockId)
+      return
+    selectedDockId = id
+    renderDocks()
   })
+
   docks.on('updated', renderDocks)
   renderDocks()
 

--- a/examples/minimal-vite-devframe-hub/src/client/style.css
+++ b/examples/minimal-vite-devframe-hub/src/client/style.css
@@ -6,45 +6,99 @@
 
 body {
   margin: 0;
-  padding: 1.5rem 2rem;
-  max-width: 800px;
-  margin-inline: auto;
+  height: 100vh;
+  overflow: hidden;
 }
 
-header h1 {
-  margin-bottom: 0.25rem;
+.app-shell {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas:
+    "header header"
+    "sidebar main"
+    "footer footer";
+  height: 100vh;
 }
 
-header p {
-  margin-top: 0;
+.app-header {
+  grid-area: header;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid color-mix(in srgb, currentcolor 20%, transparent);
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.app-header p {
+  margin: 0.25rem 0 0;
+  font-family: ui-monospace, monospace;
+  font-size: 0.8rem;
   opacity: 0.7;
 }
 
-section {
-  margin-block: 1.5rem;
+.app-sidebar {
+  grid-area: sidebar;
+  border-right: 1px solid color-mix(in srgb, currentcolor 20%, transparent);
+  padding: 0.75rem;
+  overflow: auto;
+}
+
+.app-main {
+  grid-area: main;
+  overflow: hidden;
+  background: color-mix(in srgb, currentcolor 3%, transparent);
+}
+
+.app-main iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+}
+
+.app-footer {
+  grid-area: footer;
+  display: flex;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid color-mix(in srgb, currentcolor 20%, transparent);
+  max-height: 30vh;
+  overflow: auto;
+}
+
+.app-footer section {
+  flex: 1;
+  min-width: 0;
 }
 
 h2 {
-  font-size: 1rem;
+  font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   opacity: 0.8;
-  border-bottom: 1px solid currentcolor;
-  padding-bottom: 0.25rem;
+  margin: 0 0 0.5rem;
 }
 
 ul {
   list-style: none;
   padding-left: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 li {
-  padding: 0.5rem 0.75rem;
+  padding: 0.4rem 0.6rem;
   border: 1px solid color-mix(in srgb, currentcolor 15%, transparent);
-  border-radius: 0.5rem;
-  margin-bottom: 0.5rem;
+  border-radius: 0.4rem;
   font-family: ui-monospace, monospace;
-  font-size: 0.9rem;
+  font-size: 0.8rem;
 }
 
 li.muted {
@@ -59,23 +113,51 @@ code {
   border-radius: 0.25em;
 }
 
+.app-sidebar ul li {
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.app-sidebar button {
+  width: 100%;
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  font: inherit;
+  font-size: 0.85rem;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 0.4rem;
+  cursor: pointer;
+  color: inherit;
+}
+
+.app-sidebar button:hover {
+  background: color-mix(in srgb, currentcolor 8%, transparent);
+}
+
+.app-sidebar button.active {
+  background: color-mix(in srgb, currentcolor 15%, transparent);
+  border-color: color-mix(in srgb, currentcolor 30%, transparent);
+}
+
+.actions {
+  margin-top: 0.5rem;
+}
+
 button {
   font: inherit;
-  padding: 0.5rem 1rem;
-  border-radius: 0.5rem;
+  font-size: 0.85rem;
+  padding: 0.4rem 0.8rem;
+  border-radius: 0.4rem;
   border: 1px solid currentcolor;
   background: transparent;
   cursor: pointer;
+  color: inherit;
 }
 
 button:hover {
   background: color-mix(in srgb, currentcolor 10%, transparent);
-}
-
-#status {
-  font-family: ui-monospace, monospace;
-  font-size: 0.85rem;
-  opacity: 0.7;
 }
 
 #status.error #conn {

--- a/examples/minimal-vite-devframe-hub/src/devframe-b.ts
+++ b/examples/minimal-vite-devframe-hub/src/devframe-b.ts
@@ -1,0 +1,30 @@
+import type { DevframeHubContext } from '@devframes/hub/node'
+import { fileURLToPath } from 'node:url'
+import { defineDevframe } from 'devframe/types'
+
+export default defineDevframe({
+  id: 'demo-tool-b',
+  name: 'Demo Tool B',
+  icon: 'ph:wrench-duotone',
+  basePath: '/__demo-tool-b/',
+  cli: {
+    distDir: fileURLToPath(new URL('../spa/demo-tool-b/', import.meta.url)),
+  },
+  async setup(rawCtx) {
+    const ctx = rawCtx as unknown as DevframeHubContext
+
+    ctx.commands.register({
+      id: 'demo-tool-b:say-hello',
+      title: 'Demo B · Say Hello',
+      icon: 'ph:hand-waving-duotone',
+      category: 'demo',
+      handler: () => 'Hello from demo-tool-b!',
+    })
+
+    await ctx.messages.add({
+      level: 'info',
+      message: 'Second demo devframe loaded',
+      description: 'A second mountDevframe() call — proves the switcher has more than one option.',
+    })
+  },
+})

--- a/examples/minimal-vite-devframe-hub/src/devframe.ts
+++ b/examples/minimal-vite-devframe-hub/src/devframe.ts
@@ -1,4 +1,5 @@
 import type { DevframeHubContext } from '@devframes/hub/node'
+import { fileURLToPath } from 'node:url'
 import { defineDevframe } from 'devframe/types'
 
 /**
@@ -15,6 +16,9 @@ export default defineDevframe({
   name: 'Demo Tool',
   icon: 'ph:rocket-duotone',
   basePath: '/__demo-tool/',
+  cli: {
+    distDir: fileURLToPath(new URL('../spa/demo-tool/', import.meta.url)),
+  },
   async setup(rawCtx) {
     const ctx = rawCtx as unknown as DevframeHubContext
 

--- a/examples/minimal-vite-devframe-hub/src/minimal-vite-devframe-hub.ts
+++ b/examples/minimal-vite-devframe-hub/src/minimal-vite-devframe-hub.ts
@@ -6,6 +6,7 @@ import { defineHubRpcFunction } from '@devframes/hub'
 import { createHubContext, mountDevframe } from '@devframes/hub/node'
 import { DEVFRAME_CONNECTION_META_FILENAME } from 'devframe/constants'
 import { startHttpAndWs } from 'devframe/node'
+import { serveStaticNodeMiddleware } from 'devframe/utils/serve-static'
 import { getPort } from 'get-port-please'
 import { join } from 'pathe'
 
@@ -78,10 +79,8 @@ export function minimalViteDevframeHub(options: MinimalViteDevframeHubOptions = 
       const cwd = viteConfig!.root
 
       const host: DevframeHost = {
-        mountStatic() {
-          // Static mounting for devframe SPAs would route through Vite's
-          // middleware in a fuller kit. This minimal example doesn't
-          // host any per-devframe SPA, so the no-op is honest.
+        mountStatic(base, distDir) {
+          server.middlewares.use(base, serveStaticNodeMiddleware(distDir))
         },
         resolveOrigin() {
           const resolved = server.resolvedUrls?.local?.[0]

--- a/examples/minimal-vite-devframe-hub/vite.config.ts
+++ b/examples/minimal-vite-devframe-hub/vite.config.ts
@@ -1,13 +1,14 @@
 import { defineConfig } from 'vite'
 import { alias } from '../../alias'
 import demoDevframe from './src/devframe'
+import demoDevframeB from './src/devframe-b'
 import { minimalViteDevframeHub } from './src/minimal-vite-devframe-hub'
 
 export default defineConfig({
   resolve: { alias },
   plugins: [
     minimalViteDevframeHub({
-      devframes: [demoDevframe],
+      devframes: [demoDevframe, demoDevframeB],
     }),
   ],
 })


### PR DESCRIPTION
## Summary

The two minimal hub examples (`minimal-vite-devframe-hub` and `minimal-next-devframe-hub`) previously listed docks as read-only entries — there was no way to see what mounting an iframe through `mountDevframe` actually looks like end-to-end. This PR turns both examples into faithful protocol witnesses for the iframe-mount path: a sidebar of clickable docks and a main pane that swaps the active iframe on click.

Each example now ships two demo devframes with tiny static SPAs, and each host implements `DevframeHost.mountStatic()` for real — Vite reuses `serveStaticNodeMiddleware` from `devframe/utils/serve-static`, while Next.js registers mounted SPA directories in a module-scoped map and serves them through a catch-all App Router route. The existing commands/messages/terminals panels still demonstrate the other hub subsystems, now arranged into a footer below the iframe.

This PR was created with the help of an agent.