### PR TITLE
perf(plugin-git): parallelize git show static dump

### DIFF
--- a/plugins/git/src/rpc/functions/show.ts
+++ b/plugins/git/src/rpc/functions/show.ts
@@ -9,6 +9,9 @@ const PATCH_CHAR_LIMIT = 200_000
 /** Matches the window `git:log` bakes, so any visible commit has a snapshot. */
 const SNAPSHOT_LIMIT = 200
 
+/** Read-only git detail work can run in parallel without overwhelming builds. */
+const DUMP_CONCURRENCY = 8
+
 export interface CommitFile {
   path: string
   additions: number
@@ -189,10 +192,13 @@ export const show = defineRpcFunction({
     ])
     const hashes = raw ? raw.split('\n').filter(Boolean) : []
 
-    const records = []
-    for (const hash of hashes) {
-      const output = await readCommit(git, hash, false)
-      records.push({ inputs: [{ hash }], output })
+    const records: { inputs: [{ hash: string }], output: CommitDetail }[] = []
+    for (let i = 0; i < hashes.length; i += DUMP_CONCURRENCY) {
+      const batch = hashes.slice(i, i + DUMP_CONCURRENCY)
+      const outputs = await Promise.all(batch.map(hash => readCommit(git, hash, false)))
+      batch.forEach((hash, index) => {
+        records.push({ inputs: [{ hash }], output: outputs[index] })
+      })
     }
 
     const fallback = records[0]?.output ?? { ...EMPTY_DETAIL, isRepo: true }

--- a/plugins/git/test/git.test.ts
+++ b/plugins/git/test/git.test.ts
@@ -216,6 +216,36 @@ describe('@devframes/plugin-git (build snapshot)', () => {
       repo.cleanup()
     }
   })
+
+  it('bakes git:show records for the log snapshot window', async () => {
+    const repo = createTempRepo()
+    try {
+      const ctx = await createDashboardContext(repo.dir, 'build')
+      const dump = await collectStaticRpcDump(ctx.rpc.definitions.values(), ctx)
+
+      const entry = dump.manifest['git:show']
+      expect(entry).toBeDefined()
+      expect(entry.type).toBe('query')
+      expect(Object.keys(entry.records)).toHaveLength(2)
+      expect(entry.fallback).toBeTruthy()
+
+      const recordPaths = Object.values(entry.records as Record<string, string>)
+      const details = recordPaths.map((path) => {
+        return (dump.files[path].data as { output: CommitDetail }).output
+      })
+
+      expect(details.map(detail => detail.subject)).toEqual([
+        'feat: add a.txt',
+        'init: add readme',
+      ])
+      expect(details.every(detail => detail.isRepo && detail.found)).toBe(true)
+      expect(details.every(detail => detail.patch === null)).toBe(true)
+      expect(details[0].files.map(file => file.path)).toContain('a.txt')
+    }
+    finally {
+      repo.cleanup()
+    }
+  })
 })
 
 describe('@devframes/plugin-git (write actions)', () => {


### PR DESCRIPTION
## Summary

Fixes #68

Parallelizes the `git:show` static dump so build snapshots no longer read commit details one at a time.

## Changes

- Add a bounded concurrency window for `git:show` dump generation.
- Process commit detail reads in batches of 8 with `Promise.all`.
- Preserve dump record order while reducing serialized Git subprocess latency.
- Add build snapshot coverage for `git:show` records.

## Verification

- `./node_modules/.bin/eslint --fix plugins/git/src/rpc/functions/show.ts plugins/git/test/git.test.ts`
- `./node_modules/.bin/vitest run plugins/git/test/git.test.ts`
- `./node_modules/.bin/tsc -p plugins/git/tsconfig.json --noEmit`
- `git diff --check`