### PR TITLE
perf(plugin-git): memoize commit log rows

### DIFF
--- a/plugins/git/src/client/components/views/log-panel-view.tsx
+++ b/plugins/git/src/client/components/views/log-panel-view.tsx
@@ -3,7 +3,7 @@
 import type { Commit } from '../../../index'
 import type { GraphRow } from '../../lib/commit-graph'
 import type { GitRef } from '../../lib/refs'
-import { useEffect, useMemo, useRef } from 'react'
+import { memo, useEffect, useMemo, useRef } from 'react'
 import { computeGraph } from '../../lib/commit-graph'
 import { parseRefs } from '../../lib/refs'
 import { cn } from '../../lib/utils'
@@ -165,7 +165,7 @@ function RefLabel({ refToken, color }: { refToken: GitRef, color: string }) {
   )
 }
 
-function CommitRow({ commit, row, gutter, currentBranch, isHead, topStub, selected, onSelect }: {
+const CommitRow = memo(({ commit, row, gutter, currentBranch, isHead, topStub, selected, onSelect }: {
   commit: Commit
   row: GraphRow
   gutter: number
@@ -174,7 +174,7 @@ function CommitRow({ commit, row, gutter, currentBranch, isHead, topStub, select
   topStub: boolean
   selected: boolean
   onSelect?: (hash: string) => void
-}) {
+}) => {
   const refs = useMemo(() => parseRefs(commit.refs, currentBranch), [commit.refs, currentBranch])
   const hasCurrent = refs.some(r => r.kind === 'branch' && r.current)
 
@@ -222,7 +222,7 @@ function CommitRow({ commit, row, gutter, currentBranch, isHead, topStub, select
       </button>
     </li>
   )
-}
+})
 
 function WipRow({ col, color, gutter, changes }: {
   col: number


### PR DESCRIPTION
Fixes #69
## Summary

Memoizes the Git dashboard commit row component so selection changes do not re-render every row in the accumulated commit list.

## Changes

- Wrap `CommitRow` with React `memo`.
- Preserve the existing row props and behavior.
- Keep selection handling stable through the existing `onSelectCommit` callback.

## Why

`LogPanelView` renders the commit history as an unvirtualized list. When `selectedHash` changes, only the previously selected and newly selected rows need to update, but the unmemoized row component re-rendered every visible row.

## Verification

- `./node_modules/.bin/eslint --fix plugins/git/src/client/components/views/log-panel-view.tsx`
- `./node_modules/.bin/tsc -p plugins/git/tsconfig.json --noEmit`
- `./node_modules/.bin/vitest run plugins/git/test/git.test.ts`
- `git diff --check`