### PR TITLE
fix(mcp): return structured content for tools with output schemas

### DIFF
--- a/packages/devframe/src/adapters/mcp/__tests__/mcp-server.test.ts
+++ b/packages/devframe/src/adapters/mcp/__tests__/mcp-server.test.ts
@@ -67,13 +67,20 @@ describe('mcp adapter (in-memory)', () => {
       ctx.agent.registerTool({
         id: 'echo',
         description: 'Echo.',
+        outputSchema: {
+          type: 'object',
+          properties: { echoed: { type: 'object' } },
+          required: ['echoed'],
+        },
         handler: args => ({ echoed: args }),
       })
 
+      await client.listTools()
       const result = await client.callTool({ name: 'echo', arguments: { foo: 'bar' } })
       const content = result.content as Array<{ type: string, text: string }>
       expect(content[0]!.type).toBe('text')
       expect(JSON.parse(content[0]!.text)).toEqual({ echoed: { foo: 'bar' } })
+      expect(result.structuredContent).toEqual({ echoed: { foo: 'bar' } })
     }
     finally {
       await cleanup()

--- a/packages/devframe/src/adapters/mcp/__tests__/mcp-server.test.ts
+++ b/packages/devframe/src/adapters/mcp/__tests__/mcp-server.test.ts
@@ -61,7 +61,7 @@ describe('mcp adapter (in-memory)', () => {
     }
   })
 
-  it('calls a tool and returns the text content', async () => {
+  it('returns text and structured content for a tool with an output schema', async () => {
     const { ctx, client, cleanup } = await bootPair()
     try {
       ctx.agent.registerTool({

--- a/packages/devframe/src/adapters/mcp/build-server.ts
+++ b/packages/devframe/src/adapters/mcp/build-server.ts
@@ -154,6 +154,10 @@ function registerToolHandlers(server: Server, ctx: DevframeNodeContext): void {
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params
     try {
+      const tool = ctx.agent.getTool(name)
+      const outputSchema = tool
+        ? tool.outputSchema ?? computeOutputSchema(tool, ctx)
+        : undefined
       const result = await ctx.agent.invoke(name, args ?? {})
       return {
         content: [
@@ -162,6 +166,7 @@ function registerToolHandlers(server: Server, ctx: DevframeNodeContext): void {
             text: stringifyForMcp(result),
           },
         ],
+        ...(outputSchema ? { structuredContent: result as Record<string, unknown> } : {}),
       }
     }
     catch (error) {


### PR DESCRIPTION

MCP tools that declared an `outputSchema` only returned text content. MCP SDK clients reject these calls with:

> Tool has an output schema but did not return structured content

Return the tool result through `structuredContent` whenever an output schema is exposed, while preserving the existing text content for compatibility.