### PR TITLE
fix(auth): preserve host-established trust during handshake

### DIFF
--- a/packages/devframe/src/recipes/__tests__/interactive-auth.test.ts
+++ b/packages/devframe/src/recipes/__tests__/interactive-auth.test.ts
@@ -25,7 +25,10 @@ async function createTestContext(): Promise<DevframeNodeContext> {
 }
 
 /** Starts a fully-authenticated server with one trusted-only probe method. */
-async function startAuthenticatedServer(banners: { code: string, url: string }[] = []) {
+async function startAuthenticatedServer(
+  banners: { code: string, url: string }[] = [],
+  preTrust = false,
+) {
   const context = await createTestContext()
   context.rpc.register({
     name: 'test:trusted-only',
@@ -38,7 +41,17 @@ async function startAuthenticatedServer(banners: { code: string, url: string }[]
 
   const host = '127.0.0.1'
   const port = await getPort({ port: 0, host })
-  const server = await startHttpAndWs({ context, host, port, auth })
+  const server = await startHttpAndWs({
+    context,
+    host,
+    port,
+    auth,
+    onPeerConnect: preTrust
+      ? (_peer, session) => {
+          session.meta.isTrusted = true
+        }
+      : undefined,
+  })
   return { context, auth, server, host, port }
 }
 
@@ -115,6 +128,22 @@ describe('recipes/interactive-auth', () => {
       await expect(returning.$call('test:trusted-only' as any)).resolves.toBe('ok')
       expect(getTempAuthCode()).toBe(codeAfterExchange)
       returning.$close()
+    }
+    finally {
+      await server.close()
+    }
+  })
+
+  it('preserves trust established by the host before the client handshake', async () => {
+    const { server, host, port } = await startAuthenticatedServer([], true)
+
+    try {
+      const client = connectClient(host, port)
+      const handshake = await client.$call('anonymous:devframe:auth', { authToken: '', ua: 'test', origin: 'http://localhost' })
+
+      expect(handshake).toEqual({ isTrusted: true })
+      await expect(client.$call('test:trusted-only' as any)).resolves.toBe('ok')
+      client.$close()
     }
     finally {
       await server.close()

--- a/packages/devframe/src/recipes/interactive-auth.ts
+++ b/packages/devframe/src/recipes/interactive-auth.ts
@@ -96,6 +96,8 @@ export function createInteractiveAuth(
       const session = context.rpc.getCurrentRpcSession()
       if (!session)
         return { isTrusted: false }
+      if (session.meta.isTrusted)
+        return { isTrusted: true }
       if (isStaticToken(params.authToken)) {
         session.meta.clientAuthToken = params.authToken
         session.meta.isTrusted = true


### PR DESCRIPTION
Hosts can establish trust at the transport layer before the browser runs the mandatory `anonymous:devframe:auth` handshake.

Vite DevTools standalone exposes this when client authentication is disabled in build mode: the WebSocket session is marked as trusted, but the subsequent handshake attempts to verify an empty bearer token and returns `isTrusted: false`. The client then displays an OTP authorization screen even though the server considers the connection trusted and does not print an OTP.

## Fix

Return `isTrusted: true` from the interactive auth handshake when the current session is already trusted.

This preserves trust granted by the host while keeping the existing static-token and persisted-token verification paths unchanged.