### PR TITLE
fix(hub): inherit environment in PTY sessions

### DIFF
--- a/packages/hub/src/node/__tests__/host-terminals.test.ts
+++ b/packages/hub/src/node/__tests__/host-terminals.test.ts
@@ -333,6 +333,40 @@ describe('devframeTerminalHost child-process status lifecycle', () => {
 })
 
 describe('devframeTerminalHost interactive PTY sessions', () => {
+  itPty('inherits the parent process environment', async () => {
+    expect.assertions(1)
+
+    const environmentVariable = 'DEVFRAME_PTY_INHERITED_ENV'
+    const previousValue = process.env[environmentVariable]
+    process.env[environmentVariable] = 'inherited'
+
+    let session: Awaited<ReturnType<DevframeTerminalsHost['startPtySession']>> | undefined
+    try {
+      const { host, sinks } = createTerminalHost()
+      session = await host.startPtySession({
+        command: NODE,
+        args: ['-e', `process.stdout.write(process.env.${environmentVariable} ?? "missing")`],
+      }, {
+        id: 'pty-environment',
+        title: 'PTY environment',
+      })
+
+      await waitUntil(() => {
+        if (!sinks.get('pty-environment')?.closed)
+          throw new Error('PTY stream is still open')
+      })
+
+      expect(session.buffer?.join('')).toContain('inherited')
+    }
+    finally {
+      await session?.terminate()
+      if (previousValue === undefined)
+        delete process.env[environmentVariable]
+      else
+        process.env[environmentVariable] = previousValue
+    }
+  })
+
   itPosixPty('spawns an interactive PTY that accepts input and is marked interactive', async () => {
     const { host, sinks } = createTerminalHost()
 

--- a/packages/hub/src/node/host-terminals.ts
+++ b/packages/hub/src/node/host-terminals.ts
@@ -410,6 +410,7 @@ export class DevframeTerminalsHost implements DevframeTerminalsHostType {
         rows,
         cwd: executeOptions.cwd ?? process.cwd(),
         env: {
+          ...process.env,
           TERM: PTY_TERM_NAME,
           COLORTERM: 'truecolor',
           FORCE_COLOR: '1',


### PR DESCRIPTION
## Summary

- inherit the parent process environment when spawning interactive PTY sessions
- preserve PTY defaults and explicit caller overrides
- add native PTY regression coverage for inherited environment variables

## Root cause

`startPtySession` replaced the complete process environment with terminal-specific variables. Commands launched by name consequently lost `PATH`, causing the PTY child to exit without output and leaving consumers with a blank terminal.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm run test -- --run` (891 tests)
- linked the package into ContentSquare/app-frontends and ran the `@uxanalytics/vite-helpers` suite (482 tests)