### PR TITLE
fix(hub): mark PTY session status on exit, terminate and restart

### DIFF
--- a/packages/hub/src/node/__tests__/host-terminals.test.ts
+++ b/packages/hub/src/node/__tests__/host-terminals.test.ts
@@ -436,3 +436,82 @@ describe('devframeTerminalHost interactive PTY sessions', () => {
     expect(() => session.resize(100, 30)).not.toThrow()
   })
 })
+
+describe('devframeTerminalHost PTY status lifecycle', () => {
+  itPty('marks status stopped and emits an update on a clean exit', async () => {
+    const { host } = createTerminalHost()
+    const updates: string[] = []
+    host.events.on('terminal:session:updated', s => updates.push(s.status))
+
+    const session = await host.startPtySession({
+      command: NODE,
+      args: ['-e', 'process.exit(0)'],
+    }, { id: 'pty-status', title: 'PTY status' })
+
+    await waitUntil(() => {
+      expect(session.status).toBe('stopped')
+    })
+    expect(updates).toContain('stopped')
+  })
+
+  itPty('marks status error on a non-zero exit', async () => {
+    const { host } = createTerminalHost()
+
+    const session = await host.startPtySession({
+      command: NODE,
+      args: ['-e', 'process.exit(3)'],
+    }, { id: 'pty-status-error', title: 'PTY status error' })
+
+    await waitUntil(() => {
+      expect(session.status).toBe('error')
+    })
+  })
+
+  itPty('marks status stopped on terminate() rather than error', async () => {
+    const { host, sinks } = createTerminalHost()
+
+    const session = await host.startPtySession({
+      command: NODE,
+      args: ['-e', 'setInterval(() => {}, 4000)'],
+    }, { id: 'pty-status-terminate', title: 'PTY status terminate' })
+
+    expect(session.status).toBe('running')
+    await session.terminate()
+
+    await waitUntil(() => {
+      expect(sinks.get('pty-status-terminate')?.closed).toBe(true)
+    })
+    expect(session.status).toBe('stopped')
+  })
+
+  itPty('returns to running after restart() without an error flash', async () => {
+    const { host } = createTerminalHost()
+
+    const session = await host.startPtySession({
+      command: NODE,
+      args: ['-e', 'setInterval(() => {}, 4000)'],
+    }, { id: 'pty-status-restart', title: 'PTY status restart' })
+
+    await session.restart()
+    expect(session.status).toBe('running')
+
+    await session.terminate()
+  })
+
+  itPty('keeps status stopped when restart() is called after the process exited', async () => {
+    const { host } = createTerminalHost()
+
+    const session = await host.startPtySession({
+      command: NODE,
+      args: ['-e', 'process.exit(0)'],
+    }, { id: 'pty-status-restart-exited', title: 'PTY status restart exited' })
+
+    await waitUntil(() => {
+      expect(session.status).toBe('stopped')
+    })
+    // The stream is closed for good, so `restart()` is a no-op — the session
+    // stays reported as stopped rather than flipping back to running.
+    await session.restart()
+    expect(session.status).toBe('stopped')
+  })
+})

--- a/packages/hub/src/node/host-terminals.ts
+++ b/packages/hub/src/node/host-terminals.ts
@@ -366,6 +366,18 @@ export class DevframeTerminalsHost implements DevframeTerminalsHostType {
     let pty: IPty | undefined
     let runId = 0
     let streamClosed = false
+    let session: DevframePtyTerminalSession
+
+    // Keep the registered session's `status` in step with the process
+    // lifecycle so a hub-aware client (and any launcher tracking this session)
+    // sees `running` → `stopped`/`error` transitions instead of a value frozen
+    // at spawn time.
+    const markStatus = (next: DevframeTerminalSession['status']): void => {
+      if (session.status === next)
+        return
+      session.status = next
+      this.events.emit('terminal:session:updated', session)
+    }
 
     const closeStream = () => {
       if (streamClosed)
@@ -422,9 +434,14 @@ export class DevframeTerminalsHost implements DevframeTerminalsHostType {
           return
         controller?.enqueue(typeof data === 'string' ? data : data.toString('utf8'))
       })
-      proc.onExit(() => {
-        if (currentRun === runId)
-          closeStream()
+      proc.onExit(({ exitCode, signal }) => {
+        if (currentRun !== runId)
+          return
+        closeStream()
+        // A signal kill (terminate()/restart()) is a deliberate stop; a clean
+        // exit is a deliberate stop too. Only an unsignalled non-zero exit
+        // code is a crash, matching the child-process comment above.
+        markStatus(signal === 0 && exitCode !== 0 ? 'error' : 'stopped')
       })
       return proc
     }
@@ -440,7 +457,7 @@ export class DevframeTerminalsHost implements DevframeTerminalsHostType {
       })
     }
 
-    const session: DevframePtyTerminalSession = {
+    session = {
       ...terminal,
       status: 'running',
       interactive: true,
@@ -476,12 +493,14 @@ export class DevframeTerminalsHost implements DevframeTerminalsHostType {
         pty?.kill()
         pty = undefined
         closeStream()
+        markStatus('stopped')
       },
       restart: async () => {
         if (streamClosed)
           return
         pty?.kill()
         pty = spawnPty()
+        markStatus('running')
       },
     }
     this.register(session)


### PR DESCRIPTION
## What

`startPtySession`'s `proc.onExit` only closed the output stream — it never touched the registered session's `status`, so a PTY session stayed `'running'` forever after its process was gone. 

This mirrors what `startChildProcess` already does, so the two spawn helpers now expose the same lifecycle to consumers:

- **on exit** — mark `'stopped'` on a clean or signalled exit, `'error'` on an unsignalled non-zero exit (zigpty reports `signal: 0` when no signal was involved), matching `startChildProcess`'s `typeof code === 'number' && code !== 0` classification.
- **on `terminate()`** — mark `'stopped'`, so a deliberate kill doesn't read as a crash.
- **on `restart()`** — mark `'running'`, matching `startChildProcess`'s restart. 
  This one is  symmetry rather than an observable fix: the `streamClosed` early-return means status is already `'running'` whenever the body runs, so `markStatus` de-dupes it. 
  It removes the implicit dependency on `streamClosed` and `status` staying in lockstep — the same coupling that let the exit bug hide.

Status is mutated in place through a `markStatus` helper that emits `terminal:session:updated`, copied from `startChildProcess` — consistent with `update()`'s `Object.assign` semantics, and with consumers that read `status` off the live session object (e.g. `plugins/terminals`'s manager maps `'stopped'` → `'exited'` at list time).

## What it fixes

Anything relying on `status` to learn that a PTY session ended never saw the transition — a dock watching `terminal:session:updated`, the hub's debounced `devframe:terminals:updated` broadcast, and the terminals plugin's aggregated view of foreign sessions, which all kept rendering a dead shell as running until something else forced a refresh.

## Tests

Five cases in `host-terminals.test.ts`, gated on `hasNative` like the surrounding PTY tests (0 skipped locally, so all of them genuinely ran): 
- clean exit → `'stopped'` + an emitted update, 
- non-zero exit → `'error'`, `terminate()` → `'stopped'` rather than `'error'`, 
- `restart()` → back to `'running'`, and `restart()` after exit staying `'stopped'` (pinning the `streamClosed` no-op).

`pnpm lint && pnpm test && pnpm typecheck && pnpm build` all pass.

## Note for maintainers

In both helpers the exit handler is registered before `session` is assigned — `pty = spawnPty()` precedes the session literal, as `cp = createChildProcess()` does in `startChildProcess` — so a synchronous exit delivery would throw `ReferenceError: Cannot access 'session' before initialization` from inside the callback. 

Unreachable today (both zigpty and `child_process` defer exit to the event loop), and pre-existing rather than introduced here, so I kept the existing shape rather than widen the diff. 

If you'd like it closed off, constructing the session literal before the spawn is behaviour-neutral in both methods (the closures capture the `pty` / `cp` variables, not their values), happy to add that here or in a follow-up.
