### PR TITLE
fix(data-inspector): let the saved queries list scroll instead of overflowing

### DIFF
--- a/plugins/data-inspector/src/spa/components/SavedQueriesPanel.vue
+++ b/plugins/data-inspector/src/spa/components/SavedQueriesPanel.vue
@@ -98,7 +98,7 @@ function filterBadges(entry: Query): FilterBadge[] {
 </script>
 
 <template>
-  <div class="flex flex-col gap-2">
+  <div class="flex flex-col gap-2 min-h-0">
     <div class="flex items-center gap-2">
       <div class="font-semibold text-xs op-fade uppercase tracking-wide select-none">
         Saved Queries
@@ -110,7 +110,7 @@ function filterBadges(entry: Query): FilterBadge[] {
       </ActionButton>
     </div>
 
-    <div v-if="entries.length" class="overflow-auto min-h-0 max-h-200 grid grid-cols-[repeat(auto-fit,minmax(20rem,1fr))] gap-2">
+    <div v-if="entries.length" class="flex-1 overflow-auto min-h-0 max-h-200 grid grid-cols-[repeat(auto-fit,minmax(20rem,1fr))] gap-2">
       <div
         v-for="entry in entries"
         :key="entry.key"


### PR DESCRIPTION
Make the Saved Queries list scrollable

before:
<img width="1028" height="753" alt="屏幕截图_30-7-2026_222420_localhost" src="https://github.com/user-attachments/assets/0fb0c6c1-3109-441b-985b-089f34fb2164" />

now:
<img width="1028" height="778" alt="屏幕截图_30-7-2026_222411_localhost" src="https://github.com/user-attachments/assets/878f6158-b331-4b70-8305-cc247789141b" />
