### PR TITLE
fix(devframe): reject on server listen errors instead of hanging

### DIFF
--- a/docs/errors/DF0052.md
+++ b/docs/errors/DF0052.md
@@ -1,0 +1,29 @@
+---
+outline: deep
+---
+
+# DF0052: HTTP Server Failed to Listen
+
+## Message
+
+> Failed to listen on `{host}:{port}`: `{reason}`
+
+## Cause
+
+`startHttpAndWs` tried to bind the HTTP server it owns to `host:port` and the underlying `listen()` call failed — most commonly `EADDRINUSE` (another process, often a previous devframe instance, is already bound to that port) or `EACCES` (insufficient permissions, typically a privileged port). The WS RPC transport is torn down before this error surfaces, so nothing is leaked.
+
+## Example
+
+```ts
+// A previous instance is still bound to 4096:
+// await startHttpAndWs({ context, host: 'localhost', port: 4096 }) → DF0052
+```
+
+## Fix
+
+- Free the port, or pick another via `--port`, `cli.port` / `cli.portRange` on the definition, or `devMiddleware.port` on `viteDevBridge`.
+- The original node error is available as `error.cause` — check `error.cause.code` (e.g. `'EADDRINUSE'`) to branch on the failure kind programmatically.
+
+## Source
+
+- [`packages/devframe/src/node/server.ts`](https://github.com/devframes/devframe/blob/main/packages/devframe/src/node/server.ts) — `startHttpAndWs()` throws this when its owned HTTP server's `listen()` fails.

--- a/packages/devframe/src/node/__tests__/server.test.ts
+++ b/packages/devframe/src/node/__tests__/server.test.ts
@@ -100,3 +100,19 @@ describe('startHttpAndWs rpcOptions passthrough', () => {
     }
   })
 })
+
+describe('startHttpAndWs listen failures', () => {
+  it('rejects when the port is already taken instead of hanging', async () => {
+    const host = '127.0.0.1'
+    const first = await startHttpAndWs({ context: await createTestContext(), host, port: 0, auth: false })
+
+    try {
+      await expect(
+        startHttpAndWs({ context: await createTestContext(), host, port: first.port, auth: false }),
+      ).rejects.toThrow(expect.objectContaining({ code: 'DF0052' }))
+    }
+    finally {
+      await first.close()
+    }
+  })
+})

--- a/packages/devframe/src/node/diagnostics.ts
+++ b/packages/devframe/src/node/diagnostics.ts
@@ -112,5 +112,9 @@ export const diagnostics = defineDiagnostics({
       why: (p: { port: number }) => `The devframe instance on port ${p.port} has no MCP endpoint.`,
       fix: 'Restart the instance with the --mcp flag (or set `cli.mcp: true` on its definition) to expose its tools, then list instances again.',
     },
+    DF0052: {
+      why: (p: { host: string, port: number, reason: string }) => `Failed to listen on ${p.host}:${p.port}: ${p.reason}`,
+      fix: 'The port is likely already taken by another process (often a previous devframe instance). Free it, or pick another via `--port`, `cli.port` / `cli.portRange` on the definition, or `devMiddleware.port` on `viteDevBridge`. The original node error is available as `error.cause`.',
+    },
   },
 })

--- a/packages/devframe/src/node/server.ts
+++ b/packages/devframe/src/node/server.ts
@@ -255,9 +255,25 @@ export async function startHttpAndWs(options: StartHttpAndWsOptions): Promise<St
   // Only start listening on a server we created. A shared server is already
   // (or about to be) listening under the caller's control.
   if (ownsHttpServer) {
-    await new Promise<void>((resolveListen) => {
-      httpServer.listen(port, bindHost, () => resolveListen())
-    })
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onError = (error: Error): void => reject(error)
+        // Without this listener a failed bind emits `error` with nobody
+        // attached — an uncaughtException — and the `listen` callback never
+        // fires, so this promise never settles.
+        httpServer.once('error', onError)
+        httpServer.listen(port, bindHost, () => {
+          httpServer.removeListener('error', onError)
+          resolve()
+        })
+      })
+    }
+    catch (error) {
+      // The WS transport is already attached above, so tear it down before
+      // surfacing the failure rather than leaking it and its peers.
+      await closeWs().catch(() => {})
+      throw diagnostics.DF0052({ host: bindHost, port, reason: (error as Error).message, cause: error as Error })
+    }
   }
 
   const address = httpServer.address()

--- a/packages/devframe/src/node/server.ts
+++ b/packages/devframe/src/node/server.ts
@@ -272,7 +272,12 @@ export async function startHttpAndWs(options: StartHttpAndWsOptions): Promise<St
       // The WS transport is already attached above, so tear it down before
       // surfacing the failure rather than leaking it and its peers.
       await closeWs().catch(() => {})
-      throw diagnostics.DF0052({ host: bindHost, port, reason: (error as Error).message, cause: error as Error })
+      throw diagnostics.DF0052({
+        host: bindHost,
+        port,
+        reason: error instanceof Error ? error.message : String(error),
+        cause: error,
+      })
     }
   }
 


### PR DESCRIPTION
## What

`startHttpAndWs`'s owned-server `listen()` never had an `'error'` listener anywhere in the file. On a failed bind — most commonly `EADDRINUSE`, another process (often a previous devframe instance) already on the port — two things happen at once:

- `net.Server` emits `'error'` with nobody attached, which becomes an `uncaughtException`.
- The `await new Promise(...)` around the listen call never settles, so `startHttpAndWs` (and `createDevServer`) hangs forever. `try { await createDevServer(...) } catch {}` can't see the failure at all.

This attaches a listen-scoped `'error'` handler and rejects with it instead.

## The one subtlety

By the time `listen()` runs, `attachWsRpcTransport` has already bound the WS transport, and (through `createDevServer`) the definition's `setup()` has already run. A bare reject would leak the WS server and its peers, so the fix awaits `closeWs()` — already in scope — before throwing.

## Why a diagnostic, not the raw error

The rejection is a `DF0052` diagnostic rather than the bare node error, to match the repo's structured-diagnostics convention (same `{ ...identity, reason }` + `cause` shape as `DF0045`/`DF0046`). The original error is still there as `error.cause`, so branching on `error.cause.code === 'EADDRINUSE'` keeps working, and the message already contains the code too (`listen EADDRINUSE 127.0.0.1:9999`).

## Note for maintainers

`packages/devframe/src/rpc/transports/ws-server.ts` has the identical shape (`ownedServer.listen(port, host)`, unawaited, no handler) on its dedicated-port path. Left it alone here — `attachWsRpcTransport` is a sync public export with several call sites, so awaiting its listen is a signature change that's your call, not mine to fold into a fix PR. Happy to open a follow-up if useful.

One more knock-on worth flagging: `packages/next/src/handler.ts` builds its `ready` promise eagerly, so a host that never calls `fetch()` or `close()` will now see an unhandled rejection logged instead of a silent hang — still better, but a visible change.

## Tests

New case in `packages/devframe/src/node/__tests__/server.test.ts`: start one `startHttpAndWs` instance, start a second on the same resolved port, assert `DF0052` instead of a hang.

`pnpm lint && pnpm knip && pnpm test && pnpm typecheck && pnpm build` — all green (1055 tests).
