### PR TITLE
feat(devframe): add onServerError for post-bind server errors

### DIFF
--- a/packages/devframe/src/node/server.ts
+++ b/packages/devframe/src/node/server.ts
@@ -110,6 +110,14 @@ export interface StartHttpAndWsOptions {
    * own startup banner. Devframe does not print one itself.
    */
   onReady?: (info: { origin: string, port: number, app: H3 }) => void | Promise<void>
+  /**
+   * Called for any error the owned HTTP server emits after it starts
+   * listening — e.g. a transient `EMFILE` while accepting a connection.
+   * Ignored when a `server` is supplied — the caller already owns that
+   * object and can listen on it directly. Without this, a post-bind error
+   * has no listener and crashes the process.
+   */
+  onServerError?: (error: Error) => void
 }
 
 export interface StartedServer {
@@ -258,6 +266,10 @@ export async function startHttpAndWs(options: StartHttpAndWsOptions): Promise<St
     await new Promise<void>((resolveListen) => {
       httpServer.listen(port, bindHost, () => resolveListen())
     })
+    // Attached only now that the bind has already succeeded — this never
+    // changes bind-time crash/hang semantics, only what happens afterward.
+    if (options.onServerError)
+      httpServer.on('error', options.onServerError)
   }
 
   const address = httpServer.address()

--- a/packages/devframe/src/node/server.ts
+++ b/packages/devframe/src/node/server.ts
@@ -111,11 +111,13 @@ export interface StartHttpAndWsOptions {
    */
   onReady?: (info: { origin: string, port: number, app: H3 }) => void | Promise<void>
   /**
-   * Called for any error the owned HTTP server emits after it starts
+   * Called for any error the HTTP server devframe owns emits after it starts
    * listening — e.g. a transient `EMFILE` while accepting a connection.
-   * Ignored when a `server` is supplied — the caller already owns that
-   * object and can listen on it directly. Without this, a post-bind error
-   * has no listener and crashes the process.
+   * Without it such an error has no listener and crashes the process.
+   *
+   * Applies only to a server devframe created itself. When `server` is
+   * supplied the caller owns that object and attaches to it directly, so
+   * devframe leaves its error handling alone.
    */
   onServerError?: (error: Error) => void
 }


### PR DESCRIPTION
## What

Once `startHttpAndWs`'s owned `httpServer` is past its bind, it has zero error listeners for the rest of its life — a later runtime error (a transient `EMFILE` while accepting a connection, say) still crashes the process, and there's no way for a caller to defend against it: `StartedServer` doesn't expose the underlying server, unlike the shared-server path where the caller already owns that object.

Adds `onServerError?: (error: Error) => void`, attached only after the bind has already succeeded — so it doesn't touch bind-time crash/hang semantics at all, just gives the server's remaining lifetime an escape hatch.

## Why not just expose httpServer

Considered it, but handing out the raw object would let a caller call `.close()` on it directly, bypassing the wrapper's own `close()` and leaking the WS transport — basically the same class of bug #163 fixes, through a different door. A narrow callback matches the shape the file already uses (`onReady`, `onPeerConnect`, `rpcOptions.onFunctionError`/`onGeneralError`) without that risk.

## Why it's gated on `ownsHttpServer`

Deliberate, and the JSDoc leads with it: passing `onServerError` alongside `server` does nothing.

A `net.Server` with zero `'error'` listeners crashes the process; with one, it doesn't. Attaching to a caller-supplied server would flip that server's failure mode process-wide for as long as the devframe is mounted — on a Next or Vite host that's the host's own server, and its crash semantics aren't devframe's to change. `close()` also deliberately leaves a caller-owned server running, so the listener would outlive the devframe and keep firing; making that symmetric would need a `close()`-time detach on top. And on that path the caller already holds the object, so `server.on('error', handler)` is one line on their side — the owned path having no such handle is the entire gap here. Matches how `listen`, `destroyUnmatched`, `close` and `separateWsPort` are already gated in this file.

## Note for maintainers — no test here, on purpose

`StartedServer` deliberately doesn't expose the raw server (that's the whole point of this over just exposing it), so there's no way to trigger a genuine post-bind error through the public API without adding a test-only seam. The wiring itself is a one-line pass-through of Node's own documented `'error'` event, so I'm leaving it to review rather than inventing something fragile to cover it.

I also considered forwarding bind-time errors to the same callback, so it'd be one place to observe every server error instead of two — but dropped it. That's only safe once #163's promise-settlement fix is also in: attaching any listener during the bind window changes whether Node treats a failed bind as fatal, and without #163 that trades a loud crash for a silent hang for anyone who opts in early. Independent of #163 (this PR doesn't depend on it, and applies cleanly to `main` either way), so not worth that risk here.

## Tests

`pnpm lint && pnpm knip && pnpm test && pnpm typecheck && pnpm build` — all green (1054 tests, unchanged — see above for why there's no new one).
