### PR TITLE
feat(client): add DevframeRpcClient.close()

### DIFF
--- a/packages/devframe/src/client/rpc-auth-gate.test.ts
+++ b/packages/devframe/src/client/rpc-auth-gate.test.ts
@@ -37,6 +37,8 @@ vi.mock('./rpc-ws', () => ({
     call: fakeMode.call as DevframeRpcClientMode['call'],
     callOptional: fakeMode.callOptional as DevframeRpcClientMode['callOptional'],
     callEvent: fakeMode.callEvent as DevframeRpcClientMode['callEvent'],
+    // No `close` here on purpose — `close` is optional precisely so a mode written before it
+    // existed (this one) still satisfies the interface.
   })),
 }))
 
@@ -136,5 +138,18 @@ describe('getDevframeRpcClient — auth bootstrap gates outbound calls', () => {
     await rpc.call('test:probe' as any)
     // Sent straight through — no more waiting once bootstrap is over.
     expect(fakeMode.call).toHaveBeenCalledTimes(1)
+  })
+
+  it('close() is a no-op, not a throw, against a mode that predates it', async () => {
+    const { getDevframeRpcClient } = await import('./rpc')
+    const rpc = await getDevframeRpcClient({
+      connectionMeta,
+      otpParam: false,
+      simpleAuth: false,
+    })
+
+    // The mocked mode above has no `close` at all — exactly the pre-existing-mode case
+    // `close?:` exists to keep working.
+    expect(() => rpc.close?.()).not.toThrow()
   })
 })

--- a/packages/devframe/src/client/rpc-static.ts
+++ b/packages/devframe/src/client/rpc-static.ts
@@ -35,5 +35,7 @@ export async function createStaticRpcClientMode(
       args[0] as string,
       args.slice(1),
     ),
+    // No live socket to close — every call is a local fetch.
+    close: () => {},
   }
 }

--- a/packages/devframe/src/client/rpc-ws-status.test.ts
+++ b/packages/devframe/src/client/rpc-ws-status.test.ts
@@ -148,4 +148,13 @@ describe('ws client connection status', () => {
     expect(rpcErrors[0].error).toBeInstanceOf(DevframeConnectionError)
     expect(rpcErrors[0].method).toBe('demo:method')
   })
+
+  it('close() closes the underlying socket', () => {
+    const { mode, ws } = setup()
+    const closeSpy = vi.spyOn(ws, 'close')
+
+    mode.close?.()
+
+    expect(closeSpy).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/devframe/src/client/rpc-ws.ts
+++ b/packages/devframe/src/client/rpc-ws.ts
@@ -206,34 +206,37 @@ export function createWsRpcClientMode(
   for (const name of connectionMeta.jsonSerializableMethods ?? [])
     definitions.set(name, { jsonSerializable: true })
 
+  // Hoisted out of the `createRpcClient` call so `close()` below can reach it — birpc's own
+  // `ChannelOptions` carries no reference back to what it was built from.
+  const channel = createWsRpcChannel({
+    url,
+    authToken,
+    definitions,
+    ...wsOptions,
+    onConnected(event) {
+      // Socket open — the trust handshake (already queued) settles the
+      // status to `connected`/`unauthorized`. Stay `connecting` until then.
+      wsOptions.onConnected?.(event)
+    },
+    onError(error) {
+      setStatus('error', error)
+      events.emit('connection:error', error)
+      rejectAllPending(new DevframeConnectionError('connection', '[devframe] Connection to the devframe server failed', { cause: error }))
+      wsOptions.onError?.(error)
+    },
+    onDisconnected(event) {
+      // A clean close after we were connected, or a socket that never
+      // opened — either way calls can no longer be served.
+      if (status !== 'error')
+        setStatus('disconnected')
+      rejectAllPending(new DevframeConnectionError('connection', '[devframe] Disconnected from the devframe server', { cause: connectionError ?? undefined }))
+      wsOptions.onDisconnected?.(event)
+    },
+  })
   const serverRpc = createRpcClient<DevframeRpcServerFunctions, DevframeRpcClientFunctions>(
     clientRpc.functions,
     {
-      channel: createWsRpcChannel({
-        url,
-        authToken,
-        definitions,
-        ...wsOptions,
-        onConnected(event) {
-          // Socket open — the trust handshake (already queued) settles the
-          // status to `connected`/`unauthorized`. Stay `connecting` until then.
-          wsOptions.onConnected?.(event)
-        },
-        onError(error) {
-          setStatus('error', error)
-          events.emit('connection:error', error)
-          rejectAllPending(new DevframeConnectionError('connection', '[devframe] Connection to the devframe server failed', { cause: error }))
-          wsOptions.onError?.(error)
-        },
-        onDisconnected(event) {
-          // A clean close after we were connected, or a socket that never
-          // opened — either way calls can no longer be served.
-          if (status !== 'error')
-            setStatus('disconnected')
-          rejectAllPending(new DevframeConnectionError('connection', '[devframe] Disconnected from the devframe server', { cause: connectionError ?? undefined }))
-          wsOptions.onDisconnected?.(event)
-        },
-      }),
+      channel,
       rpcOptions,
     },
   )
@@ -401,6 +404,9 @@ export function createWsRpcClientMode(
         ),
         method,
       )
+    },
+    close: () => {
+      channel.close()
     },
   }
 }

--- a/packages/devframe/src/client/rpc.test.ts
+++ b/packages/devframe/src/client/rpc.test.ts
@@ -159,4 +159,39 @@ describe('getDevframeRpcClient — connection meta base', () => {
     // An explicit meta resolves against the client's own base.
     expect(lastWsUrl()).toBe('ws://localhost:5173/__foo/__ws')
   })
+
+  it('close() closes the underlying socket', async () => {
+    const served: ConnectionMeta = { backend: 'websocket', websocket: { path: '__ws' } }
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => served,
+    }) as any))
+
+    const rpc = await getDevframeRpcClient({ baseURL: '/__foo/', otpParam: false })
+    const ws = FakeWebSocket.instances.at(-1)!
+    const closeSpy = vi.spyOn(ws, 'close')
+
+    rpc.close?.()
+
+    expect(closeSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('close() on a static backend is a no-op, not a throw', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => ({
+      ok: true,
+      status: 200,
+      json: async () => (
+        url.includes('__rpc-dump')
+          ? {} // an empty manifest is a valid (if trivial) StaticRpcManifest
+          : { backend: 'static' } satisfies ConnectionMeta
+      ),
+    }) as any))
+
+    const rpc = await getDevframeRpcClient({ baseURL: '/__foo/', otpParam: false })
+
+    expect(() => rpc.close?.()).not.toThrow()
+    // Static backends never open a socket in the first place.
+    expect(FakeWebSocket.instances).toHaveLength(0)
+  })
 })

--- a/packages/devframe/src/client/rpc.ts
+++ b/packages/devframe/src/client/rpc.ts
@@ -195,6 +195,20 @@ export interface DevframeRpcClient {
     <NS extends string>(namespace: NS): DevframeScopedClientContext<NS, SettingsForNamespace<NS>>
     (namespace?: null | ''): DevframeRpcClient
   }
+
+  /**
+   * Close the connection. A `static` backend is a no-op (there is no live socket to close);
+   * a `websocket` backend closes the underlying `WebSocket`, which the server observes as a
+   * normal disconnect. Mirrors {@link WsRpcTransport.close} on the server side.
+   *
+   * There is no corresponding "reconnect" — a closed client is done. Discard it and call
+   * {@link getDevframeRpcClient} again to reconnect.
+   *
+   * Optional so a `DevframeRpcClientMode` implemented before this method existed — a custom
+   * transport, a hand-typed mock — still satisfies the interface; an absent `close` is treated
+   * as nothing to close.
+   */
+  close?: () => void
 }
 
 export interface DevframeRpcClientMode {
@@ -212,6 +226,8 @@ export interface DevframeRpcClientMode {
   call: DevframeRpcClient['call']
   callEvent: DevframeRpcClient['callEvent']
   callOptional: DevframeRpcClient['callOptional']
+  /** See {@link DevframeRpcClient.close}. */
+  close?: () => void
 }
 
 export async function getDevframeRpcClient(
@@ -375,6 +391,7 @@ export async function getDevframeRpcClient(
     streaming: undefined!,
     cacheManager,
     scope: undefined!,
+    close: () => mode.close?.(),
   }
 
   rpc.sharedState = createRpcSharedStateClientHost(rpc)

--- a/packages/devframe/src/rpc/transports/ws-client.test.ts
+++ b/packages/devframe/src/rpc/transports/ws-client.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createWsRpcChannel } from './ws-client'
+
+// A minimal fake WebSocket — only what `createWsRpcChannel` touches.
+class FakeWebSocket {
+  static OPEN = 1
+  static instances: FakeWebSocket[] = []
+
+  readyState = FakeWebSocket.OPEN
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this)
+  }
+
+  addEventListener(): void {}
+  removeEventListener(): void {}
+  send(): void {}
+  close(): void {}
+}
+
+describe('createWsRpcChannel', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = []
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('close() closes the underlying socket', () => {
+    const channel = createWsRpcChannel({ url: 'ws://localhost:5173/__ws' })
+    const ws = FakeWebSocket.instances.at(-1)!
+    const closeSpy = vi.spyOn(ws, 'close')
+
+    channel.close()
+
+    expect(closeSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/devframe/src/rpc/transports/ws-client.ts
+++ b/packages/devframe/src/rpc/transports/ws-client.ts
@@ -27,8 +27,11 @@ const EMPTY_DEFS: ReadonlyMap<string, Pick<RpcFunctionDefinitionAny, 'jsonSerial
 /**
  * Build a birpc `ChannelOptions` object backed by a browser `WebSocket`.
  * Pass the result straight to `createRpcClient`'s `channel` option.
+ *
+ * Also returns `close()`, closing the underlying socket — mirroring the server transport's
+ * existing `WsRpcTransport.close()`. `birpc`'s own `ChannelOptions` has no teardown of its own.
  */
-export function createWsRpcChannel(options: WsRpcChannelOptions): ChannelOptions {
+export function createWsRpcChannel(options: WsRpcChannelOptions): ChannelOptions & { close: () => void } {
   let url = options.url
   if (options.authToken) {
     url = `${url}?${DEVFRAME_AUTH_TOKEN_QUERY_PARAM}=${encodeURIComponent(options.authToken)}`
@@ -59,6 +62,9 @@ export function createWsRpcChannel(options: WsRpcChannelOptions): ChannelOptions
   // method up in `definitions` and pick the right encoder.
   const pendingRequestMethods = new Map<string, string>()
   return {
+    close: () => {
+      ws.close()
+    },
     on: (handler: (data: string) => void) => {
       ws.addEventListener('message', (e) => {
         handler(e.data)

--- a/tests/__snapshots__/tsnapi/devframe/client.snapshot.d.ts
+++ b/tests/__snapshots__/tsnapi/devframe/client.snapshot.d.ts
@@ -29,6 +29,7 @@ export interface DevframeRpcClient {
     <NS extends string>(_: NS): DevframeScopedClientContext<NS, SettingsForNamespace<NS>>;
     (_?: null | ''): DevframeRpcClient;
   };
+  close?: () => void;
 }
 export interface DevframeRpcClientMode {
   readonly isTrusted: boolean;
@@ -41,6 +42,7 @@ export interface DevframeRpcClientMode {
   call: DevframeRpcClient['call'];
   callEvent: DevframeRpcClient['callEvent'];
   callOptional: DevframeRpcClient['callOptional'];
+  close?: () => void;
 }
 export interface DevframeRpcClientOptions extends SetupDevframeConnectionOptions {
   authToken?: string;


### PR DESCRIPTION
## What

`DevframeRpcClient` has no `close()`/`dispose()` of any kind — a connection lives until the process ends, with no way for a caller to tear it down. The server transport already has the symmetric piece: `WsRpcTransport.close()` (`attachWsRpcTransport`) detaches upgrade routing, force-closes every connected peer, and closes any server it created itself. The client side has never had an equivalent.

This bites any caller that races a connection attempt against its own deadline (`Promise.race([connectDevframe(...), timeout])`) — the deadline can't cancel the loser, so a slow-to-resolve attempt becomes a fully connected, unreferenced client with nothing able to close it. That's the concrete case that surfaced this: [@contentsquare/devkit](https://github.com/ContentSquare/app-frontends) carries a local patch adding this exact method so its connection-deadline and `disconnect()` paths can close what they no longer want, rather than leaking it.

`createWsRpcChannel` returns `close()`, closing the underlying `WebSocket` — widening its return type to `ChannelOptions & { close: () => void }`, since birpc's own `ChannelOptions` has no teardown of its own. `createWsRpcClientMode` hoists its channel to a local so it can reach it, and exposes `close()` on `DevframeRpcClientMode`. `DevframeRpcClient.close()` delegates to the mode. Purely additive: no behavior change for anyone not calling it.

## Why a no-op `close()` on the static backend, not an optional one

`createStaticRpcClientMode` has no live socket — every call is a local fetch — so its `close()` does nothing. Making it optional instead (`close?: () => void`) would push the "does this mode support closing" question onto every caller of `DevframeRpcClientMode`/`DevframeRpcClient`, for no real benefit: the two modes already union-compatible on every other method this way (`requestTrustWithCode`, `ensureTrusted`, …), and a no-op is exactly as safe to call as a real one.

## Why not just expose the `WebSocket`

Handing back the raw socket would let a caller close it out from under the channel without the channel's own bookkeeping (`pendingRequestMethods`, the queued-send cleanup in `post`) ever running — the same class of bug #165 declined to reintroduce by not exposing `httpServer` on the server side. A narrow `close()` matches that precedent and the shape `WsRpcTransport.close()` already established server-side.

## Why `close()` doesn't also reject pending calls

It doesn't need to. Closing the socket fires the channel's own `close` listener, which `createWsRpcClientMode` already wires to `onDisconnected` → `rejectAllPending(...)` — the exact path a real disconnect takes. Adding a second, separate rejection here would just race the first.

## Note for maintainers

Opening as draft since I'm an external consumer proposing this from downstream need, not a maintainer. Two things I'd rather leave to you than decide unilaterally:

- **Naming.** `close()` mirrors the server transport's own `WsRpcTransport.close()`, but `dispose()`/`Symbol.dispose` are also reasonable given `DevframeRpcClient` is a resource with a lifetime. Happy to rename either way.
- **Async or sync.** `WsRpcTransport.close()` is `async` (it awaits `ownedServer.close()`); this one is sync, since `WebSocket.close()` itself doesn't return anything to await and there's nothing else here to wait on. Flagging the asymmetry in case you'd rather keep the two `close()`s the same shape regardless.

## Tests

- `ws-client.test.ts` (new): `close()` closes the underlying `WebSocket`.
- `rpc-ws-status.test.ts`: `createWsRpcClientMode`'s `close()` closes its socket.
- `rpc.test.ts`: `getDevframeRpcClient`'s `close()` closes the socket on a `websocket` backend, and is a no-op (not a throw) on a `static` one.
- `rpc-auth-gate.test.ts`: updated its hand-typed `DevframeRpcClientMode` mock for the new required field.

`pnpm --filter devframe exec tsc --noEmit` clean. `pnpm exec vitest run --project devframe` — 51 files, 463 tests (was 459), all green. Also ran `--project @devframes/hub --project @devframes/hub-ui` (129 tests) and `tsc --noEmit` across `@devframes/hub`, `@devframes/hub-ui`, `@devframes/nuxt` — the packages consuming `DevframeRpcClient` — clean. `eslint` clean on every touched file.
