### PR TITLE
fix(hub-ui): apply branding primaryColor to the popped-out dock

### DIFF
--- a/packages/hub-ui/src/client/state/popup.ts
+++ b/packages/hub-ui/src/client/state/popup.ts
@@ -1,7 +1,7 @@
 import type { DocksContext } from '@devframes/hub/client'
 import { createEventEmitter } from 'devframe/utils/events'
 import { shallowRef, watch } from 'vue'
-import { applyDocumentHead, useBranding } from './branding'
+import { applyDocumentHead, applyPrimaryColor, useBranding } from './branding'
 import { isDark } from './color-mode'
 import { setDocksOverflowPanel } from './floating-tooltip'
 
@@ -130,6 +130,10 @@ async function mountStandaloneApp(context: DocksContext, popup: Window) {
   popup.document.body.appendChild(appRoot)
 
   const dockElement = new DockStandaloneElement({ context })
+  // The popup is its own document, so the inline `--devframe-primary` on the
+  // embedded host can't inherit across — apply it here too, or the `:host` ramp
+  // falls back to the default palette.
+  applyPrimaryColor(dockElement, useBranding().value.primaryColor)
   popupDockElement = dockElement
   appRoot.appendChild(dockElement)
 }


### PR DESCRIPTION
Fixed the inconsistent theme color in popup mode.

before:
<img width="1253" height="648" alt="屏幕截图_17-8-2026_164456_" src="https://github.com/user-attachments/assets/6646adc0-38be-4078-9d4e-7ca4b1ef8828" />

now:
<img width="1262" height="648" alt="屏幕截图_17-8-2026_164419_" src="https://github.com/user-attachments/assets/13c238ef-f08b-42ac-b992-d811cdcf9188" />
