### PR TITLE
fix(hub-ui): restore scrolling for edge panel content at top/bottom

### DIFF
--- a/packages/hub-ui/src/client/components/dock/DockEdge.stories.ts
+++ b/packages/hub-ui/src/client/components/dock/DockEdge.stories.ts
@@ -1,8 +1,10 @@
+import type { DevframeViewBuiltin } from '@devframes/hub'
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
 import { h } from 'vue'
 import { categorizedEntries, groupedEntries } from '../../stories/fixtures'
 import { mountWithContext } from '../../stories/story-helpers'
 import FloatingElements from '../floating/FloatingElements.vue'
+import ViewBuiltinSettings from '../views-builtin/ViewBuiltinSettings.vue'
 import DockEdge from './DockEdge.vue'
 
 /** A stand-in panel body (the real one mounts iframe/custom views). */
@@ -82,6 +84,35 @@ export const CollapsedIdle: Story = {
       },
       ctx => [
         h(DockEdge, { context: ctx }, { view: ({ entry }: any) => body(entry) }),
+        h(FloatingElements),
+      ],
+    ),
+  }),
+}
+
+const settingsEntry: DevframeViewBuiltin = {
+  type: '~builtin',
+  id: '~settings',
+  title: 'Settings',
+  icon: 'ph:gear-duotone',
+}
+
+/**
+ * Bottom edge hosting the real Settings view, whose tab content is taller than
+ * the panel. Guards the panel's main-axis height chain: the other stories stub
+ * `#view` with short, self-scrolling content, so they cannot catch a content
+ * wrapper that grows past the panel instead of letting descendants scroll.
+ */
+export const BottomWithSettings: Story = {
+  render: () => ({
+    setup: () => mountWithContext(
+      {
+        entries: categorizedEntries,
+        selectedId: 'overview',
+        panel: { mode: 'edge', position: 'bottom', height: 40 },
+      },
+      ctx => [
+        h(DockEdge, { context: ctx }, { view: () => h(ViewBuiltinSettings, { context: ctx, entry: settingsEntry }) }),
         h(FloatingElements),
       ],
     ),

--- a/packages/hub-ui/src/client/components/dock/DockEdge.vue
+++ b/packages/hub-ui/src/client/components/dock/DockEdge.vue
@@ -363,8 +363,8 @@ const toolbarClass = computed(() => {
 
 const contentClass = computed(() => {
   return isVertical.value
-    ? 'flex-1 h-full overflow-clip'
-    : 'flex-1 w-full overflow-clip'
+    ? 'flex-1 h-full min-w-0 overflow-clip'
+    : 'flex-1 w-full min-h-0 overflow-clip'
 })
 
 /** A thin band flush with the candidate edge, tracking the drag before it commits on release. */


### PR DESCRIPTION
Fixed an issue where panel content could not scroll in Edge mode when positioned at the top or bottom.