### PR TITLE
fix(hub-ui): reduce light dock panel glass opacity

### DIFF
--- a/packages/hub-ui/src/client/components/dock/DockEdge.stories.ts
+++ b/packages/hub-ui/src/client/components/dock/DockEdge.stories.ts
@@ -135,3 +135,37 @@ export const WithGroup: Story = {
     ),
   }),
 }
+
+function patternedEdgeStory(theme: 'light' | 'dark'): Story {
+  return {
+    globals: { theme },
+    render: () => ({
+      setup: () => mountWithContext(
+        {
+          entries: categorizedEntries,
+          selectedId: 'overview',
+          panel: { mode: 'edge', position: 'bottom', height: 40, width: 30 },
+          session: { open: true },
+        },
+        ctx => h('div', { class: 'relative w-screen h-screen overflow-hidden bg-secondary bg-grid-24' }, [
+          h('div', {
+            'aria-hidden': 'true',
+            'class': 'pointer-events-none absolute left-[14%] top-[36%] h-72 w-72 rounded-full bg-primary-500 op40',
+          }),
+          h('div', {
+            'aria-hidden': 'true',
+            'class': 'pointer-events-none absolute right-[12%] bottom-[8%] h-40 w-72 rounded-3xl bg-active',
+          }),
+          h(DockEdge, { context: ctx }, { view: ({ entry }: any) => body(entry) }),
+          h(FloatingElements),
+        ]),
+      ),
+    }),
+  }
+}
+
+/** Tinted glass edge material blurring a grid in light mode. */
+export const GlassMaterialLight: Story = patternedEdgeStory('light')
+
+/** Tinted glass edge material blurring a grid in dark mode. */
+export const GlassMaterialDark: Story = patternedEdgeStory('dark')

--- a/packages/hub-ui/src/client/components/dock/DockEdge.vue
+++ b/packages/hub-ui/src/client/components/dock/DockEdge.vue
@@ -407,7 +407,7 @@ const dragPreviewStyle = computed<CSSProperties | undefined>(() => {
 <template>
   <div
     id="devframes-edge-panel"
-    class="bg-glass:80 border border-base color-base shadow overflow-clip z-floating-anchor font-sans text-[15px] box-border"
+    class="bg-dock-glass border border-base color-base shadow overflow-clip z-floating-anchor font-sans text-[15px] box-border"
     :class="[panelLayoutClass, { 'devframes-edge-collapsed': isCollapsed }]"
     :style="panelStyle"
     @mousemove="bringUp"

--- a/packages/hub-ui/src/client/components/dock/DockPanel.stories.ts
+++ b/packages/hub-ui/src/client/components/dock/DockPanel.stories.ts
@@ -72,3 +72,37 @@ export const RightAnchored: Story = {
     ),
   }),
 }
+
+function patternedPanelStory(theme: 'light' | 'dark'): Story {
+  return {
+    globals: { theme },
+    render: () => ({
+      setup: () => mountWithContext(
+        { entries: categorizedEntries, selectedId: 'overview', panel: { position: 'bottom', left: 50, top: 100, width: 60, height: 60 } },
+        ctx => h('div', { class: 'relative w-screen h-screen overflow-hidden bg-secondary bg-grid-24' }, [
+          h('div', {
+            'aria-hidden': 'true',
+            'class': 'pointer-events-none absolute left-[14%] top-[36%] h-72 w-72 rounded-full bg-primary-500 op40',
+          }),
+          h('div', {
+            'aria-hidden': 'true',
+            'class': 'pointer-events-none absolute right-[12%] bottom-[8%] h-40 w-72 rounded-3xl bg-active',
+          }),
+          h('div', { id: 'devframes-anchor', style: { left: '50vw', top: '100vh' } }, [
+            h(DockPanel, {
+              context: ctx,
+              selected: ctx.docks.selected,
+              panelMargins: MARGINS,
+            }, { view: ({ entry }: any) => body(entry) }),
+          ]),
+        ]),
+      ),
+    }),
+  }
+}
+
+/** Tinted glass panel material blurring a grid in light mode. */
+export const GlassMaterialLight: Story = patternedPanelStory('light')
+
+/** Tinted glass panel material blurring a grid in dark mode. */
+export const GlassMaterialDark: Story = patternedPanelStory('dark')

--- a/packages/hub-ui/src/client/components/dock/DockPanel.vue
+++ b/packages/hub-ui/src/client/components/dock/DockPanel.vue
@@ -175,7 +175,7 @@ onMounted(() => {
   <div
     v-show="context.docks.selected && context.docks.selected.type !== 'action'"
     ref="dockPanel"
-    class="bg-glass:80 rounded-lg border border-base color-base shadow overflow-hidden"
+    class="bg-dock-glass rounded-lg border border-base color-base shadow overflow-hidden"
     :style="panelStyle"
     @contextmenu="openContextMenu"
   >

--- a/packages/hub-ui/uno.config.ts
+++ b/packages/hub-ui/uno.config.ts
@@ -24,6 +24,8 @@ export default mergeConfigs([
       },
     },
     shortcuts: {
+      /** Use the lighter glass in light mode while retaining dark-mode contrast. */
+      'bg-dock-glass': 'bg-glass dark:bg-[#111]/80',
       // Dock-shell z-layers (named — the design preset blocks plain
       // `z-<number>`). The floating shell layers sit at the very top of the
       // host page's stacking order, mirroring the upstream dock.


### PR DESCRIPTION
## What changed

- add a local `bg-dock-glass` material that uses the default glass tint in light mode and retains the existing 80% tint in dark mode
- apply it to `DockPanel` and `DockEdge`, keeping their borders and shadows
- leave the command palette, toasts, popovers, and other hub overlays unchanged
- add patterned light and dark stories for both panel modes

## Why

`bg-glass:80` resolves to fully opaque white in light mode, hiding the inspected page. The default `bg-glass` material reduces that light tint to 65%, so underlying content remains visible through the existing blur.

In dark mode, the existing 80% `#111` tint already provides the right separation and contrast. The local shortcut preserves it instead of adopting the default glass material's lower 50% dark opacity. Both schemes retain `blur(7px)` and use the design system's existing glass values.

## Light theme

### Before

<img width="1200" height="800" alt="Light theme before: opaque dock panel" src="https://github.com/user-attachments/assets/c8690bee-78c5-4a76-a281-ba88cf32e556" />

### After

<img width="1200" height="800" alt="Light theme after: 65% glass dock panel with blurred page accents visible beneath it" src="https://github.com/user-attachments/assets/6c3f7598-5597-40aa-b9f4-55824d3edbed" />

## Dark theme

The dark comparison is intentionally visually stable: this change preserves the existing 80% dark material.

### Before

<img width="1200" height="800" alt="Dark theme before: 80% glass dock panel" src="https://github.com/user-attachments/assets/ea4ebe16-2e9e-4ddd-9899-ef92b2919b24" />

### After

<img width="1200" height="800" alt="Dark theme after: retained 80% glass dock panel with blurred page accents visible beneath it" src="https://github.com/user-attachments/assets/362f30bb-8f99-47ec-8fcc-dc0e79649e51" />

## Verification

- `pnpm lint`
- `pnpm knip`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- computed floating and edge panel styles: 65% white in light mode, 80% `#111` in dark mode, and `blur(7px)` in both

Refs #267
