### PR TITLE
fix(hub-ui): reserve space for settings scrollbar

### DIFF
--- a/packages/hub-ui/src/client/components/views-builtin/ViewBuiltinSettings.vue
+++ b/packages/hub-ui/src/client/components/views-builtin/ViewBuiltinSettings.vue
@@ -48,7 +48,7 @@ const settingsStore = props.context.docks.settings
     </div>
 
     <!-- Tab content -->
-    <div class="flex-1 overflow-auto p8">
+    <div class="flex-1 overflow-auto p8" style="scrollbar-gutter: stable;">
       <div class="max-w-200 mx-auto">
         <SettingsAppearance
           v-if="activeTab === 'appearance'"


### PR DESCRIPTION
Fixed an issue where the Settings panel's scroll container did not reserve space for the scrollbar.
