### PR TITLE
fix(json-render-ui): add the missing CSS reset to the SPA and Storybook

### DIFF
--- a/packages/json-render-ui/.storybook/preview.ts
+++ b/packages/json-render-ui/.storybook/preview.ts
@@ -1,4 +1,7 @@
 import type { Decorator, Preview } from '@storybook/vue3-vite'
+// Before `virtual:uno.css`, mirroring the SPA entry and the shadow-root build —
+// see `src/spa/main.ts` for why the reset is load-bearing here.
+import '@unocss/reset/tailwind.css'
 import 'virtual:uno.css'
 import '@antfu/design/styles.css'
 

--- a/packages/json-render-ui/package.json
+++ b/packages/json-render-ui/package.json
@@ -58,6 +58,7 @@
     "@storybook/addon-docs": "catalog:storybook",
     "@storybook/vue3-vite": "catalog:storybook",
     "@unocss/preset-icons": "catalog:frontend",
+    "@unocss/reset": "catalog:frontend",
     "@vitejs/plugin-vue": "catalog:build",
     "devframe": "workspace:*",
     "storybook": "catalog:storybook",

--- a/packages/json-render-ui/src/JsonRender.stories.ts
+++ b/packages/json-render-ui/src/JsonRender.stories.ts
@@ -127,7 +127,16 @@ const dockRendererContext = {
   rpc: { call: rpc.call, connectionMeta: undefined },
 } as unknown as Parameters<typeof jsonRenderDockRenderer>[0]['context']
 
-/** Mounts the shipped dock renderer so the story exercises its shadow root and adopted stylesheet. */
+/**
+ * Mounts the shipped dock renderer so the story exercises its shadow root and
+ * adopted stylesheet.
+ *
+ * It renders `gallerySpec`, so it should look **the same** as `Gallery` — the
+ * two differ only in how the stylesheet reaches the components (Storybook's
+ * `virtual:uno.css` in the light DOM vs. the prebuilt `.generated/css` adopted
+ * into a shadow root). A visible divergence between them means one of the two
+ * pipelines has drifted, not that the shadow root is "styled differently".
+ */
 export const InShadowRoot: StoryObj = {
   render: () => ({
     setup() {

--- a/packages/json-render-ui/src/spa/main.ts
+++ b/packages/json-render-ui/src/spa/main.ts
@@ -4,6 +4,17 @@ import { JSON_RENDER_INDEX_KEY } from '@devframes/json-render'
 import { connectDevframe } from 'devframe/client'
 import { computed, createApp, defineComponent, h, ref, shallowReactive, shallowRef, watch } from 'vue'
 import { JsonRenderView } from '../renderer'
+// The same Tailwind preflight `scripts/build-css.ts` prepends to the shipped
+// shadow-root stylesheet — first, so `virtual:uno.css`'s utilities win over its
+// resets, matching the production build's `[reset, userStyle, unoCss]` order.
+// The `@antfu/design` component ports depend on it: `btn-action` (what
+// `Button.ts` maps `secondary`/`ghost` onto) sets a border and `op75` but *no*
+// base `background-color` — only one on `:hover` — so without the reset the UA
+// default `button { background-color: buttonface }` wins and every non-primary
+// button renders as a solid light-grey box. The dock renderer never showed this
+// because its stylesheet is built with the reset baked in; this SPA and the
+// Storybook canvas are the two surfaces that have to import it themselves.
+import '@unocss/reset/tailwind.css'
 import 'virtual:uno.css'
 import '@antfu/design/styles.css'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1558,6 +1558,9 @@ importers:
       '@unocss/preset-icons':
         specifier: catalog:frontend
         version: 66.7.5
+      '@unocss/reset':
+        specifier: catalog:frontend
+        version: 66.7.5
       '@vitejs/plugin-vue':
         specifier: catalog:build
         version: 6.0.8(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))


### PR DESCRIPTION
## Problem

`btn-action` / `btn-action-sm` — what `Button.ts` maps the `secondary` and `ghost` variants onto — set a border and `op75` but **no base `background-color`**, only one on `:hover`:

```css
.btn-action-sm{--un-border-opacity:.13;border-width:1px;border-color:rgb(136 136 136/var(--un-border-opacity));opacity:.75;…}
.btn-action:hover,.btn-action-sm:hover{--un-bg-opacity:.13;background-color:rgb(136 136 136/var(--un-bg-opacity));opacity:1}
```

That is correct only if a CSS reset has neutralised the UA's `button { background-color: buttonface }`. Without one, the browser default wins and every non-primary button renders as a **solid light-grey box with dark text** on the dark canvas.

`design/build-shadow-css.ts` prepends `@unocss/reset/tailwind.css` to the shadow-root stylesheet, so the dock renderer was never affected — which is why this went unnoticed. The two light-DOM surfaces have to import the reset themselves, and neither did.

## Evidence

Reset markers present in each pipeline's built CSS, before this change:

| pipeline | `-webkit-appearance:button` | `background-image:none` | `box-sizing:border-box` |
| --- | --- | --- | --- |
| shadow build (`src/.generated/css.ts`) | 1 | 1 | 1 |
| shipped SPA (`dist/spa/assets/*.css`) | **0** | **0** | **0** |
| Storybook (`iframe-*.css`) | **0** | **0** | **0** |

After this change all three rows read `1`.

Note the middle row: this affects the **shipped SPA bundle**, not just the Storybook canvas.

## Prior art in this repo

`packages/hub-ui/.storybook/preview.ts` already does exactly this, and its comment describes this precise symptom:

> Without it, stories miss the reset (unstyled default `<button>`/`<ul>`/heading margins, …) real dock content never shows once mounted in its actual shadow root.

`json-render-ui` simply never got the same line. `@unocss/reset` is already in the catalog (`pnpm-workspace.yaml:155`) and already declared by the root `package.json` and by `hub-ui`; this adds the third declaration.

`hub-ui` itself is **not** affected — it ships no light-DOM SPA (`virtual:uno.css` appears only in its Storybook preview), so its two surfaces both already have the reset.

## Changes

- `src/spa/main.ts` — import `@unocss/reset/tailwind.css` before `virtual:uno.css`, matching the shadow build's `[reset, userStyle, unoCss]` order, with the rationale inline.
- `.storybook/preview.ts` — same import, pointing at the SPA entry for the explanation.
- `package.json` — declare `@unocss/reset: catalog:frontend` rather than relying on transitive hoisting.
- `JsonRender.stories.ts` — comment on `InShadowRoot` noting it renders `gallerySpec` and should therefore look *the same* as `Gallery`; divergence means a pipeline drifted. The two stories now act as a cheap visual regression pair.

## Verification

- `tsc --noEmit` passes; `eslint` clean on all changed files.
- SPA and Storybook both rebuilt; reset rules confirmed present in the output CSS.
- `pnpm install --frozen-lockfile` passes; the lockfile diff is three lines (the added dependency) and nothing else.

before: 

<img width="1923" height="1112" alt="屏幕截图_22-8-2026_161523_localhost" src="https://github.com/user-attachments/assets/fdef6ae1-6542-4a01-ada2-6896c9db0d09" />

<img width="1879" height="723" alt="屏幕截图_22-8-2026_161526_localhost" src="https://github.com/user-attachments/assets/408648bc-3df9-4d6c-a1cc-666df113f8b9" />

now: 

<img width="1767" height="1161" alt="屏幕截图_22-8-2026_16185_localhost" src="https://github.com/user-attachments/assets/525653aa-ff18-4039-adf1-4092dbce139e" />

<img width="1801" height="1216" alt="屏幕截图_22-8-2026_16189_localhost" src="https://github.com/user-attachments/assets/3582f2f1-14f0-4b59-86ee-ee00cf8cdca0" />