### PR TITLE
fix(hub-ui): support persistent toast notifications

### DIFF
--- a/packages/hub-ui/src/client/state/toasts.test.ts
+++ b/packages/hub-ui/src/client/state/toasts.test.ts
@@ -1,0 +1,69 @@
+import type { DevframeMessageEntry } from '@devframes/hub'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { addToast, dismissToast, useToasts } from './toasts'
+
+function createMessage(id: string, autoDismiss: number | false): DevframeMessageEntry {
+  return {
+    id,
+    message: id,
+    level: 'info',
+    from: 'browser',
+    timestamp: 0,
+    autoDismiss,
+  }
+}
+
+function dismissAllToasts(): void {
+  for (const toast of [...useToasts()])
+    dismissToast(toast.id)
+}
+
+describe('toast auto-dismiss', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    dismissAllToasts()
+  })
+
+  afterEach(() => {
+    dismissAllToasts()
+    vi.useRealTimers()
+  })
+
+  it('keeps a persistent toast visible until it is explicitly dismissed', () => {
+    addToast(createMessage('persistent', false))
+
+    expect(vi.getTimerCount()).toBe(0)
+
+    vi.advanceTimersByTime(60_000)
+
+    expect(useToasts()).toHaveLength(1)
+
+    dismissToast('persistent')
+
+    expect(useToasts()).toHaveLength(0)
+  })
+
+  it('cancels an existing auto-dismiss timer when its toast becomes persistent', () => {
+    addToast(createMessage('updated', 1_000))
+
+    expect(vi.getTimerCount()).toBe(1)
+
+    addToast(createMessage('updated', false))
+
+    expect(vi.getTimerCount()).toBe(0)
+
+    vi.advanceTimersByTime(60_000)
+
+    expect(useToasts()).toHaveLength(1)
+  })
+
+  it('continues to auto-dismiss timed toasts', () => {
+    addToast(createMessage('timed', 1_000))
+
+    vi.advanceTimersByTime(999)
+    expect(useToasts()).toHaveLength(1)
+
+    vi.advanceTimersByTime(1)
+    expect(useToasts()).toHaveLength(0)
+  })
+})

--- a/packages/hub-ui/src/client/state/toasts.ts
+++ b/packages/hub-ui/src/client/state/toasts.ts
@@ -21,10 +21,13 @@ export function addToast(entry: DevframeMessageEntry): void {
     existing.entry = entry
     // Reset auto-dismiss timer
     const timer = timers.get(entry.id)
-    if (timer)
+    if (timer) {
       clearTimeout(timer)
+      timers.delete(entry.id)
+    }
     const timeout = entry.autoDismiss ?? 5000
-    timers.set(entry.id, setTimeout(dismissToast, timeout, entry.id))
+    if (timeout !== false)
+      timers.set(entry.id, setTimeout(dismissToast, timeout, entry.id))
     return
   }
 
@@ -32,7 +35,8 @@ export function addToast(entry: DevframeMessageEntry): void {
   toasts.push(item)
 
   const timeout = entry.autoDismiss ?? 5000
-  timers.set(entry.id, setTimeout(dismissToast, timeout, entry.id))
+  if (timeout !== false)
+    timers.set(entry.id, setTimeout(dismissToast, timeout, entry.id))
 }
 
 export function dismissToast(id: string): void {

--- a/packages/hub/src/types/messages.ts
+++ b/packages/hub/src/types/messages.ts
@@ -109,7 +109,8 @@ export interface DevframeMessageEntry {
    */
   actions?: DevframeMessageAction[]
   /**
-   * Time in ms to auto-dismiss the toast notification (client-side)
+   * Time in ms to auto-dismiss the toast notification (client-side) or
+   * `false` to keep it indefinitely.
    */
   autoDismiss?: number | false
   /**

--- a/packages/hub/src/types/messages.ts
+++ b/packages/hub/src/types/messages.ts
@@ -111,7 +111,7 @@ export interface DevframeMessageEntry {
   /**
    * Time in ms to auto-dismiss the toast notification (client-side)
    */
-  autoDismiss?: number
+  autoDismiss?: number | false
   /**
    * Time in ms to auto-delete this message entry (server-side)
    */

--- a/tests/__snapshots__/tsnapi/@devframes/hub/index.snapshot.d.ts
+++ b/tests/__snapshots__/tsnapi/@devframes/hub/index.snapshot.d.ts
@@ -173,7 +173,7 @@ export interface DevframeMessageEntry {
   category?: string;
   labels?: string[];
   actions?: DevframeMessageAction[];
-  autoDismiss?: number;
+  autoDismiss?: number | false;
   autoDelete?: number;
   timestamp: number;
   status?: 'loading' | 'idle';


### PR DESCRIPTION
## Summary

- allow `autoDismiss: false` in the public message type
- keep persistent toasts visible until explicit dismissal
- cancel an existing timer when a timed toast becomes persistent
- cover persistent, updated, and timed toast behavior with fake-timer tests

## Validation

- `pnpm lint`
- `pnpm knip`
- `pnpm test` (117 files, 1,274 passed, 9 skipped)
- `pnpm typecheck` (38 tasks)
- `pnpm build` (27 tasks)