### PR TITLE
feat(hub-ui): support transparent standalone viewers

### DIFF
--- a/docs/content/1.guide/18.hub-initiate.md
+++ b/docs/content/1.guide/18.hub-initiate.md
@@ -61,8 +61,8 @@ interface DevframeHubUi {
 
 `@devframes/hub-ui`'s `createUi()` is the reference (standalone `viewer` SPA + floating dock); its `setup(ctx)` publishes config to `ctx.staticConfig.ui` (`ConnectionMeta.configs.ui`):
 
-- **`viewer`** — set to `false` to disable the standalone viewer, or `{ background: 'transparent' }` when its document should visually inherit an embedding page's surface.
-- **`branding`** — rebrand the UI (logo, name, primary color).
+- **`viewer`** — set to `false` to disable the standalone viewer.
+- **`branding`** — rebrand the UI (logo, name, primary color), or set `background: 'transparent'` when the standalone viewer should reveal the host page behind its iframe.
 - **`dockPreferences`** — dock-rail: `categoryOrder`, floating-dock `maxVisibleItems`, first-run `defaultMode` (`'float'`/`'edge'`) and `defaultPosition`.
 - **`embeddedVisibility`** — the floating dock's reveal policy:
   - `'normal'` (default) — shows immediately.

--- a/docs/content/1.guide/18.hub-initiate.md
+++ b/docs/content/1.guide/18.hub-initiate.md
@@ -62,7 +62,7 @@ interface DevframeHubUi {
 `@devframes/hub-ui`'s `createUi()` is the reference (standalone `viewer` SPA + floating dock); its `setup(ctx)` publishes config to `ctx.staticConfig.ui` (`ConnectionMeta.configs.ui`):
 
 - **`viewer`** — set to `false` to disable the standalone viewer.
-- **`branding`** — rebrand the UI (logo, name, primary color), or set `background: 'transparent'` when the standalone viewer should reveal the host page behind its iframe.
+- **`branding`** — rebrand the UI (logo, name, primary color). `background` accepts any CSS `background` value (color, gradient, image, or `transparent`) or `{ light, dark }` variants; omit it to keep the design default.
 - **`dockPreferences`** — dock-rail: `categoryOrder`, floating-dock `maxVisibleItems`, first-run `defaultMode` (`'float'`/`'edge'`) and `defaultPosition`.
 - **`embeddedVisibility`** — the floating dock's reveal policy:
   - `'normal'` (default) — shows immediately.

--- a/docs/content/1.guide/18.hub-initiate.md
+++ b/docs/content/1.guide/18.hub-initiate.md
@@ -61,6 +61,7 @@ interface DevframeHubUi {
 
 `@devframes/hub-ui`'s `createUi()` is the reference (standalone `viewer` SPA + floating dock); its `setup(ctx)` publishes config to `ctx.staticConfig.ui` (`ConnectionMeta.configs.ui`):
 
+- **`viewer`** — set to `false` to disable the standalone viewer, or `{ background: 'transparent' }` when its document should visually inherit an embedding page's surface.
 - **`branding`** — rebrand the UI (logo, name, primary color).
 - **`dockPreferences`** — dock-rail: `categoryOrder`, floating-dock `maxVisibleItems`, first-run `defaultMode` (`'float'`/`'edge'`) and `defaultPosition`.
 - **`embeddedVisibility`** — the floating dock's reveal policy:

--- a/packages/hub-ui/src/client/standalone/index.html
+++ b/packages/hub-ui/src/client/standalone/index.html
@@ -6,19 +6,23 @@
     <title>Devframes</title>
     <meta name="description" content="Devframes hub" />
     <style>
+      :root {
+        color-scheme: light;
+        --devframes-viewer-background: #fff;
+      }
+      html.dark {
+        color-scheme: dark;
+        --devframes-viewer-background: #111;
+      }
+      html.viewer-background-transparent {
+        color-scheme: normal;
+        --devframes-viewer-background: transparent;
+      }
       html,
       body {
         margin: 0;
         height: 100%;
-        background: #fff;
-      }
-      html.dark,
-      html.dark body {
-        background: #111;
-      }
-      html.viewer-background-transparent,
-      html.viewer-background-transparent body {
-        background: transparent;
+        background: var(--devframes-viewer-background);
       }
       #app {
         height: 100%;

--- a/packages/hub-ui/src/client/standalone/index.html
+++ b/packages/hub-ui/src/client/standalone/index.html
@@ -14,9 +14,8 @@
         color-scheme: dark;
         --devframes-viewer-background: #111;
       }
-      html.viewer-background-transparent {
+      html.viewer-background-custom {
         color-scheme: normal;
-        --devframes-viewer-background: transparent;
       }
       html,
       body {

--- a/packages/hub-ui/src/client/standalone/index.html
+++ b/packages/hub-ui/src/client/standalone/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Devframes</title>
     <meta name="description" content="Devframes hub" />
+    <link rel="stylesheet" href="./__hub-ui.css" />
     <style>
       html,
       body {

--- a/packages/hub-ui/src/client/standalone/index.html
+++ b/packages/hub-ui/src/client/standalone/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Devframes</title>
     <meta name="description" content="Devframes hub" />
-    <link rel="stylesheet" href="./__hub-ui.css" />
     <style>
       html,
       body {
@@ -16,6 +15,10 @@
       html.dark,
       html.dark body {
         background: #111;
+      }
+      html.viewer-background-transparent,
+      html.viewer-background-transparent body {
+        background: transparent;
       }
       #app {
         height: 100%;

--- a/packages/hub-ui/src/client/standalone/main.ts
+++ b/packages/hub-ui/src/client/standalone/main.ts
@@ -39,6 +39,7 @@ async function main(): Promise<void> {
   // established above.
   const branding = setBranding(rpc.connectionMeta.configs?.ui?.branding || {})
   applyDocumentHead(document, branding)
+  document.documentElement.classList.toggle('viewer-background-transparent', branding.background === 'transparent')
 
   // Per-tab session UI state (which dock is open + its route). `sessionStorage`
   // so a reload restores the selection after the auth handshake, per-tab.

--- a/packages/hub-ui/src/client/standalone/main.ts
+++ b/packages/hub-ui/src/client/standalone/main.ts
@@ -18,18 +18,22 @@ import { DEFAULT_DOCK_SESSION_STORE } from '../state/docks'
 // off the document lets custom backgrounds composite with the host page.
 const brandingBackground = useBrandingBackground()
 
+function applyViewerBackground(documentElement: HTMLElement, background: string | undefined): void {
+  if (background === undefined || !CSS.supports('background', background)) {
+    documentElement.classList.remove('viewer-background-custom')
+    documentElement.style.removeProperty('--devframes-viewer-background')
+    return
+  }
+
+  documentElement.classList.add('viewer-background-custom')
+  documentElement.style.setProperty('--devframes-viewer-background', background)
+}
+
 watchEffect(() => {
   const el = document.documentElement
   el.classList.toggle('dark', isDark.value)
   el.classList.toggle('light', !isDark.value)
-
-  const background = brandingBackground.value
-  const hasValidBackground = background !== undefined && CSS.supports('background', background)
-  el.classList.toggle('viewer-background-custom', hasValidBackground)
-  if (hasValidBackground)
-    el.style.setProperty('--devframes-viewer-background', background)
-  else
-    el.style.removeProperty('--devframes-viewer-background')
+  applyViewerBackground(el, brandingBackground.value)
 })
 
 async function main(): Promise<void> {

--- a/packages/hub-ui/src/client/standalone/main.ts
+++ b/packages/hub-ui/src/client/standalone/main.ts
@@ -2,7 +2,7 @@ import type { DockSessionStorage } from '@devframes/hub/client'
 import { getDevframeRpcClient, setDevframeClientContext } from '@devframes/hub/client'
 import { useSessionStorage } from '@vueuse/core'
 import { watchEffect } from 'vue'
-import { applyDocumentHead, applyPrimaryColor, setBranding } from '../state/branding'
+import { applyDocumentHead, applyPrimaryColor, setBranding, useBrandingBackground } from '../state/branding'
 import { isDark } from '../state/color-mode'
 import { DEFAULT_DOCK_SESSION_STORE } from '../state/docks'
 
@@ -15,11 +15,21 @@ import { DEFAULT_DOCK_SESSION_STORE } from '../state/docks'
 // The standalone viewer runs in the light DOM, so mirror the color mode onto the
 // document element — its background follows the Auto/Light/Dark choice. The
 // component tree carries `color-scheme` for its native controls; keeping that
-// off the document lets the transparent viewer reveal the host page.
+// off the document lets custom backgrounds composite with the host page.
+const brandingBackground = useBrandingBackground()
+
 watchEffect(() => {
   const el = document.documentElement
   el.classList.toggle('dark', isDark.value)
   el.classList.toggle('light', !isDark.value)
+
+  const background = brandingBackground.value
+  const hasValidBackground = background !== undefined && CSS.supports('background', background)
+  el.classList.toggle('viewer-background-custom', hasValidBackground)
+  if (hasValidBackground)
+    el.style.setProperty('--devframes-viewer-background', background)
+  else
+    el.style.removeProperty('--devframes-viewer-background')
 })
 
 async function main(): Promise<void> {
@@ -39,7 +49,6 @@ async function main(): Promise<void> {
   // established above.
   const branding = setBranding(rpc.connectionMeta.configs?.ui?.branding || {})
   applyDocumentHead(document, branding)
-  document.documentElement.classList.toggle('viewer-background-transparent', branding.background === 'transparent')
 
   // Per-tab session UI state (which dock is open + its route). `sessionStorage`
   // so a reload restores the selection after the auth handshake, per-tab.

--- a/packages/hub-ui/src/client/standalone/main.ts
+++ b/packages/hub-ui/src/client/standalone/main.ts
@@ -12,14 +12,14 @@ import { DEFAULT_DOCK_SESSION_STORE } from '../state/docks'
 // shell stays frameworkless on purpose; everything visual lives inside the
 // custom element's shadow root.
 
-// The standalone page runs in the light DOM, so mirror the color mode onto the
-// document element — its background and native controls follow the
-// Auto/Light/Dark choice.
+// The standalone viewer runs in the light DOM, so mirror the color mode onto the
+// document element — its background follows the Auto/Light/Dark choice. The
+// component tree carries `color-scheme` for its native controls; keeping that
+// off the document lets the transparent viewer reveal the host page.
 watchEffect(() => {
   const el = document.documentElement
   el.classList.toggle('dark', isDark.value)
   el.classList.toggle('light', !isDark.value)
-  el.style.colorScheme = isDark.value ? 'dark' : 'light'
 })
 
 async function main(): Promise<void> {

--- a/packages/hub-ui/src/client/state/branding.test.ts
+++ b/packages/hub-ui/src/client/state/branding.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { setBranding, useBrandingBackground } from './branding'
+import { setColorSchemePreference } from './color-mode'
+
+afterEach(() => {
+  setBranding({})
+  setColorSchemePreference('auto')
+})
+
+describe('useBrandingBackground', () => {
+  it('preserves an empty dark value for CSS validation', () => {
+    expect.assertions(1)
+
+    setColorSchemePreference('dark')
+    setBranding({ background: { light: 'white', dark: '' } })
+
+    expect(useBrandingBackground().value).toBe('')
+  })
+})

--- a/packages/hub-ui/src/client/state/branding.ts
+++ b/packages/hub-ui/src/client/state/branding.ts
@@ -3,6 +3,8 @@ import type { BrandingLogo, DevframeBranding } from '../../types'
 import { computed, ref } from 'vue'
 import { isDark } from './color-mode'
 
+type ColorSchemeValue = string | { light: string, dark: string }
+
 /** Branding with defaults resolved — what the UI actually renders. */
 export interface ResolvedBranding {
   productName: string
@@ -54,7 +56,7 @@ export function useBrandingBackground(): Ref<string | undefined> {
   return computed(() => resolveColorSchemeValue(currentBranding.value.background, isDark.value))
 }
 
-function resolveColorSchemeValue(value: BrandingLogo | undefined, dark: boolean): string | undefined {
+function resolveColorSchemeValue(value: ColorSchemeValue | undefined, dark: boolean): string | undefined {
   if (!value)
     return undefined
   if (typeof value === 'string')

--- a/packages/hub-ui/src/client/state/branding.ts
+++ b/packages/hub-ui/src/client/state/branding.ts
@@ -9,6 +9,7 @@ export interface ResolvedBranding {
   logo?: BrandingLogo
   wordmark?: BrandingLogo
   primaryColor?: string
+  background: 'default' | 'transparent'
   tagline?: string
   favicon?: string
   windowTitle: string
@@ -23,6 +24,7 @@ function resolveDefaults(branding: DevframeBranding): ResolvedBranding {
     logo: branding.logo,
     wordmark: branding.wordmark,
     primaryColor: branding.primaryColor,
+    background: branding.background || 'default',
     tagline: branding.tagline,
     favicon: branding.favicon,
     windowTitle: branding.windowTitle?.trim() || productName,

--- a/packages/hub-ui/src/client/state/branding.ts
+++ b/packages/hub-ui/src/client/state/branding.ts
@@ -61,7 +61,7 @@ function resolveColorSchemeValue(value: ColorSchemeValue | undefined, dark: bool
     return undefined
   if (typeof value === 'string')
     return value
-  return dark ? (value.dark || value.light) : value.light
+  return dark ? (value.dark ?? value.light) : value.light
 }
 
 // --- Applying to the DOM --------------------------------------------------

--- a/packages/hub-ui/src/client/state/branding.ts
+++ b/packages/hub-ui/src/client/state/branding.ts
@@ -9,7 +9,7 @@ export interface ResolvedBranding {
   logo?: BrandingLogo
   wordmark?: BrandingLogo
   primaryColor?: string
-  background: 'default' | 'transparent'
+  background?: DevframeBranding['background']
   tagline?: string
   favicon?: string
   windowTitle: string
@@ -24,7 +24,7 @@ function resolveDefaults(branding: DevframeBranding): ResolvedBranding {
     logo: branding.logo,
     wordmark: branding.wordmark,
     primaryColor: branding.primaryColor,
-    background: branding.background || 'default',
+    background: branding.background,
     tagline: branding.tagline,
     favicon: branding.favicon,
     windowTitle: branding.windowTitle?.trim() || productName,
@@ -46,15 +46,20 @@ export function setBranding(branding: DevframeBranding): ResolvedBranding {
 
 /** The logo/wordmark URL for the current color scheme, reactive to it. */
 export function useBrandingLogo(pick: (b: ResolvedBranding) => BrandingLogo | undefined = b => b.logo): Ref<string | undefined> {
-  return computed(() => resolveLogo(pick(currentBranding.value), isDark.value))
+  return computed(() => resolveColorSchemeValue(pick(currentBranding.value), isDark.value))
 }
 
-function resolveLogo(logo: BrandingLogo | undefined, dark: boolean): string | undefined {
-  if (!logo)
+/** The standalone viewer background for the current color scheme. */
+export function useBrandingBackground(): Ref<string | undefined> {
+  return computed(() => resolveColorSchemeValue(currentBranding.value.background, isDark.value))
+}
+
+function resolveColorSchemeValue(value: BrandingLogo | undefined, dark: boolean): string | undefined {
+  if (!value)
     return undefined
-  if (typeof logo === 'string')
-    return logo
-  return dark ? (logo.dark || logo.light) : logo.light
+  if (typeof value === 'string')
+    return value
+  return dark ? (value.dark || value.light) : value.light
 }
 
 // --- Applying to the DOM --------------------------------------------------

--- a/packages/hub-ui/src/index.test.ts
+++ b/packages/hub-ui/src/index.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { createUi } from './index'
+
+describe('createUi viewer background', () => {
+  it('loads the runtime viewer stylesheet from the production HTML', () => {
+    expect.assertions(1)
+
+    const html = readFileSync(join(import.meta.dirname, '..', 'dist', 'client', 'standalone', 'index.html'), 'utf8')
+
+    expect(html).toContain('<link rel="stylesheet" href="./__hub-ui.css" />')
+  })
+
+  it('preserves the default viewer background', () => {
+    expect.assertions(1)
+
+    const ui = createUi()
+
+    expect(ui.assets?.['__hub-ui.css']()).toBe('')
+  })
+
+  it('provides a transparent viewer background when requested', () => {
+    expect.assertions(1)
+
+    const ui = createUi({ viewer: { background: 'transparent' } })
+
+    expect(ui.assets?.['__hub-ui.css']()).toBe('html,body{background:transparent!important}')
+  })
+
+  it('does not publish viewer assets when the viewer is disabled', () => {
+    expect.assertions(2)
+
+    const ui = createUi({ viewer: false })
+
+    expect(ui.viewer).toBeUndefined()
+    expect(ui.assets).toBeUndefined()
+  })
+})

--- a/packages/hub-ui/src/index.test.ts
+++ b/packages/hub-ui/src/index.test.ts
@@ -1,39 +1,52 @@
+import type { DevframeHubContext } from '@devframes/hub/node'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { createUi } from './index'
 
-describe('createUi viewer background', () => {
-  it('loads the runtime viewer stylesheet from the production HTML', () => {
-    expect.assertions(1)
+function createContext(): DevframeHubContext {
+  return { staticConfig: {} } as unknown as DevframeHubContext
+}
+
+describe('createUi branding background', () => {
+  it('keeps the viewer stylesheet static', () => {
+    expect.assertions(2)
 
     const html = readFileSync(join(import.meta.dirname, '..', 'dist', 'client', 'standalone', 'index.html'), 'utf8')
 
-    expect(html).toContain('<link rel="stylesheet" href="./__hub-ui.css" />')
+    expect(html).not.toContain('__hub-ui.css')
+    expect(html).toContain('html.viewer-background-transparent')
   })
 
   it('preserves the default viewer background', () => {
-    expect.assertions(1)
-
-    const ui = createUi()
-
-    expect(ui.assets?.['__hub-ui.css']()).toBe('')
-  })
-
-  it('provides a transparent viewer background when requested', () => {
-    expect.assertions(1)
-
-    const ui = createUi({ viewer: { background: 'transparent' } })
-
-    expect(ui.assets?.['__hub-ui.css']()).toBe('html,body{background:transparent!important}')
-  })
-
-  it('does not publish viewer assets when the viewer is disabled', () => {
     expect.assertions(2)
+
+    const context = createContext()
+    const ui = createUi()
+    ui.setup?.(context)
+
+    expect(context.staticConfig.ui).toEqual({ branding: {} })
+    expect(ui.assets).toBeUndefined()
+  })
+
+  it('publishes a transparent viewer background with the branding', () => {
+    expect.assertions(2)
+
+    const context = createContext()
+    const ui = createUi({ branding: { background: 'transparent' } })
+    ui.setup?.(context)
+
+    expect(context.staticConfig.ui).toEqual({
+      branding: { background: 'transparent' },
+    })
+    expect(ui.assets).toBeUndefined()
+  })
+
+  it('disables the standalone viewer', () => {
+    expect.assertions(1)
 
     const ui = createUi({ viewer: false })
 
     expect(ui.viewer).toBeUndefined()
-    expect(ui.assets).toBeUndefined()
   })
 })

--- a/packages/hub-ui/src/index.test.ts
+++ b/packages/hub-ui/src/index.test.ts
@@ -9,13 +9,16 @@ function createContext(): DevframeHubContext {
 }
 
 describe('createUi branding background', () => {
-  it('keeps the viewer stylesheet static', () => {
-    expect.assertions(2)
+  it('defines the viewer background through a static token', () => {
+    expect.assertions(5)
 
     const html = readFileSync(join(import.meta.dirname, '..', 'dist', 'client', 'standalone', 'index.html'), 'utf8')
 
     expect(html).not.toContain('__hub-ui.css')
     expect(html).toContain('html.viewer-background-transparent')
+    expect(html).toContain('--devframes-viewer-background: transparent')
+    expect(html).toContain('background: var(--devframes-viewer-background)')
+    expect(html).toMatch(/html\.viewer-background-transparent\s*\{[^}]*color-scheme:\s*normal/)
   })
 
   it('preserves the default viewer background', () => {

--- a/packages/hub-ui/src/index.test.ts
+++ b/packages/hub-ui/src/index.test.ts
@@ -1,6 +1,6 @@
 import type { DevframeHubContext } from '@devframes/hub/node'
 import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { createUi } from './index'
 
@@ -10,15 +10,16 @@ function createContext(): DevframeHubContext {
 
 describe('createUi branding background', () => {
   it('defines the viewer background through a static token', () => {
-    expect.assertions(5)
+    expect.assertions(6)
 
-    const html = readFileSync(join(import.meta.dirname, '..', 'dist', 'client', 'standalone', 'index.html'), 'utf8')
+    const html = readFileSync(fileURLToPath(new URL('../dist/client/standalone/index.html', import.meta.url)), 'utf8')
 
     expect(html).not.toContain('__hub-ui.css')
-    expect(html).toContain('html.viewer-background-transparent')
-    expect(html).toContain('--devframes-viewer-background: transparent')
+    expect(html).toContain('html.viewer-background-custom')
+    expect(html).toContain('--devframes-viewer-background: #fff')
+    expect(html).toContain('--devframes-viewer-background: #111')
     expect(html).toContain('background: var(--devframes-viewer-background)')
-    expect(html).toMatch(/html\.viewer-background-transparent\s*\{[^}]*color-scheme:\s*normal/)
+    expect(html).toMatch(/html\.viewer-background-custom\s*\{[^}]*color-scheme:\s*normal/)
   })
 
   it('preserves the default viewer background', () => {
@@ -32,7 +33,7 @@ describe('createUi branding background', () => {
     expect(ui.assets).toBeUndefined()
   })
 
-  it('publishes a transparent viewer background with the branding', () => {
+  it('publishes a CSS viewer background with the branding', () => {
     expect.assertions(2)
 
     const context = createContext()
@@ -43,6 +44,20 @@ describe('createUi branding background', () => {
       branding: { background: 'transparent' },
     })
     expect(ui.assets).toBeUndefined()
+  })
+
+  it('publishes color-scheme viewer backgrounds with the branding', () => {
+    expect.assertions(1)
+
+    const context = createContext()
+    const background = {
+      light: 'linear-gradient(white, transparent)',
+      dark: 'linear-gradient(#111, transparent)',
+    }
+    const ui = createUi({ branding: { background } })
+    ui.setup?.(context)
+
+    expect(context.staticConfig.ui).toEqual({ branding: { background } })
   })
 
   it('disables the standalone viewer', () => {

--- a/packages/hub-ui/src/index.ts
+++ b/packages/hub-ui/src/index.ts
@@ -33,8 +33,14 @@ function clientDir(): string {
 }
 
 export interface CreateUiOptions {
-  /** Serve the standalone viewer SPA at the hub base. Default: `true`. */
-  viewer?: boolean
+  /**
+   * Serve the standalone viewer SPA at the hub base. Pass an object to
+   * customize the viewer surface. Default: `true`.
+   */
+  viewer?: boolean | {
+    /** Page background used around transparent renderer content. Default: `'default'`. */
+    background?: 'default' | 'transparent'
+  }
   /** Serve the floating-dock bootstrap at `<base>embedded.js`. Default: `true`. */
   embedded?: boolean
   /**
@@ -87,12 +93,22 @@ export interface CreateUiOptions {
  */
 export function createUi(options: CreateUiOptions = {}): DevframeHubUi {
   const client = clientDir()
+  const viewerBackground = typeof options.viewer === 'object' ? options.viewer.background : undefined
   return {
     ...(options.viewer !== false
       ? { viewer: { distDir: join(client, 'standalone') } }
       : {}),
     ...(options.embedded !== false
       ? { embedded: { entry: join(client, 'embedded.js') } }
+      : {}),
+    ...(options.viewer !== false
+      ? {
+          assets: {
+            '__hub-ui.css': () => viewerBackground === 'transparent'
+              ? 'html,body{background:transparent!important}'
+              : '',
+          },
+        }
       : {}),
     // Publish the reference UI's config through the generic `ctx.staticConfig`
     // — it rides the connection handshake to every mounted frame and the

--- a/packages/hub-ui/src/index.ts
+++ b/packages/hub-ui/src/index.ts
@@ -33,14 +33,8 @@ function clientDir(): string {
 }
 
 export interface CreateUiOptions {
-  /**
-   * Serve the standalone viewer SPA at the hub base. Pass an object to
-   * customize the viewer surface. Default: `true`.
-   */
-  viewer?: boolean | {
-    /** Page background used around transparent renderer content. Default: `'default'`. */
-    background?: 'default' | 'transparent'
-  }
+  /** Serve the standalone viewer SPA at the hub base. Default: `true`. */
+  viewer?: boolean
   /** Serve the floating-dock bootstrap at `<base>embedded.js`. Default: `true`. */
   embedded?: boolean
   /**
@@ -93,22 +87,12 @@ export interface CreateUiOptions {
  */
 export function createUi(options: CreateUiOptions = {}): DevframeHubUi {
   const client = clientDir()
-  const viewerBackground = typeof options.viewer === 'object' ? options.viewer.background : undefined
   return {
     ...(options.viewer !== false
       ? { viewer: { distDir: join(client, 'standalone') } }
       : {}),
     ...(options.embedded !== false
       ? { embedded: { entry: join(client, 'embedded.js') } }
-      : {}),
-    ...(options.viewer !== false
-      ? {
-          assets: {
-            '__hub-ui.css': () => viewerBackground === 'transparent'
-              ? 'html,body{background:transparent!important}'
-              : '',
-          },
-        }
       : {}),
     // Publish the reference UI's config through the generic `ctx.staticConfig`
     // — it rides the connection handshake to every mounted frame and the

--- a/packages/hub-ui/src/types.ts
+++ b/packages/hub-ui/src/types.ts
@@ -31,8 +31,8 @@ export interface DevframeBranding {
   wordmark?: BrandingLogo
   /** Brand color; feeds `--devframe-primary` and the whole primary ramp. */
   primaryColor?: string
-  /** Standalone viewer background. Default: `'default'`. */
-  background?: 'default' | 'transparent'
+  /** Standalone viewer CSS `background`; a string applies to both color schemes. */
+  background?: string | { light: string, dark: string }
   /** Short line for the auth screen and the standalone meta description. */
   tagline?: string
   /** Favicon URL — applied on the standalone viewer and the popped-out window only. */

--- a/packages/hub-ui/src/types.ts
+++ b/packages/hub-ui/src/types.ts
@@ -31,6 +31,8 @@ export interface DevframeBranding {
   wordmark?: BrandingLogo
   /** Brand color; feeds `--devframe-primary` and the whole primary ramp. */
   primaryColor?: string
+  /** Standalone viewer background. Default: `'default'`. */
+  background?: 'default' | 'transparent'
   /** Short line for the auth screen and the standalone meta description. */
   tagline?: string
   /** Favicon URL — applied on the standalone viewer and the popped-out window only. */

--- a/tests/__snapshots__/tsnapi/@devframes/hub-ui/index.snapshot.d.ts
+++ b/tests/__snapshots__/tsnapi/@devframes/hub-ui/index.snapshot.d.ts
@@ -3,7 +3,9 @@
  */
 // #region Interfaces
 export interface CreateUiOptions {
-  viewer?: boolean;
+  viewer?: boolean | {
+    background?: 'default' | 'transparent';
+  };
   embedded?: boolean;
   branding?: DevframeBranding;
   embeddedVisibility?: EmbeddedVisibility;

--- a/tests/__snapshots__/tsnapi/@devframes/hub-ui/index.snapshot.d.ts
+++ b/tests/__snapshots__/tsnapi/@devframes/hub-ui/index.snapshot.d.ts
@@ -3,9 +3,7 @@
  */
 // #region Interfaces
 export interface CreateUiOptions {
-  viewer?: boolean | {
-    background?: 'default' | 'transparent';
-  };
+  viewer?: boolean;
   embedded?: boolean;
   branding?: DevframeBranding;
   embeddedVisibility?: EmbeddedVisibility;
@@ -16,6 +14,7 @@ export interface DevframeBranding {
   logo?: BrandingLogo;
   wordmark?: BrandingLogo;
   primaryColor?: string;
+  background?: 'default' | 'transparent';
   tagline?: string;
   favicon?: string;
   windowTitle?: string;

--- a/tests/__snapshots__/tsnapi/@devframes/hub-ui/index.snapshot.d.ts
+++ b/tests/__snapshots__/tsnapi/@devframes/hub-ui/index.snapshot.d.ts
@@ -14,7 +14,10 @@ export interface DevframeBranding {
   logo?: BrandingLogo;
   wordmark?: BrandingLogo;
   primaryColor?: string;
-  background?: 'default' | 'transparent';
+  background?: string | {
+    light: string;
+    dark: string;
+  };
   tagline?: string;
   favicon?: string;
   windowTitle?: string;


### PR DESCRIPTION
## What changed

- let `createUi({ branding: { background } })` accept any valid CSS `background` shorthand
- accept either one value for both color schemes or `{ light, dark }` variants
- validate the active value with `CSS.supports('background', value)` and retain the default when it is invalid
- apply valid values through the static `--devframes-viewer-background` token
- use a custom-background selector with `color-scheme: normal` so transparent and translucent backgrounds composite with the host page
- keep the existing default light and dark backgrounds when `background` is omitted

## Why

Applications embedding the standalone viewer may need its document background to match or composite with the surrounding host page. A CSS background value supports solid colors, gradients, images, alpha colors, and `transparent` without adding a special mode for each case.

The host page cannot reliably style a cross-origin iframe document, so the value travels through the existing branding configuration and is applied by the standalone viewer.

## Usage

```ts
createUi({
  branding: {
    background: {
      light: 'linear-gradient(rgb(255 255 255 / 80%), transparent)',
      dark: 'linear-gradient(rgb(17 17 17 / 80%), transparent)',
    },
  },
})
```

A string applies to both color schemes:

```ts
createUi({ branding: { background: 'transparent' } })
```

## Implementation

The packaged viewer stylesheet remains static. Its HTML defines `--devframes-viewer-background` as `#fff` in light mode and `#111` in dark mode. The browser entry resolves the configured string or active light/dark variant, checks it with `CSS.supports`, and sets the token only when valid.

Valid custom backgrounds enable a static selector that sets the document's `color-scheme` to `normal`. This preserves iframe compositing for `transparent`, alpha colors, and translucent gradients, while the component tree retains its light or dark `color-scheme` for native controls. Invalid values leave the default token untouched.

The Hub publishes no request-specific stylesheet or extra asset route.

## Visual comparison

| Default viewer background | Transparent viewer background |
| --- | --- |
| <img width="1280" height="720" alt="Standalone viewer repainting the host page" src="https://github.com/user-attachments/assets/8cd3476d-c87e-47e8-a5cc-22978c6a7db7" /> | <img width="1280" height="720" alt="Standalone viewer revealing the host page" src="https://github.com/user-attachments/assets/0721dadc-25e7-44b6-9d0a-508085a464be" /> |

## Compatibility

Existing `createUi()` calls retain the current opaque light and dark standalone viewer backgrounds. Disabling the standalone viewer with `viewer: false` also keeps its existing behavior. Background URLs are accepted as trusted application configuration.

## Validation

- `pnpm lint`
- `pnpm knip`
- `pnpm typecheck`
- `pnpm test`: 120 files passed, 1,323 tests passed, 9 skipped
- focused Hub UI behavior and API snapshot tests: 7 passed, 249 skipped
- real Chromium iframe checks:
  - `transparent` revealed the host page
  - a translucent gradient composited over the host page
  - light/dark variants switched with the active color scheme
  - an invalid value retained the default background
  - omitted configuration retained the opaque default
