### PR TITLE
fix(hub-ui): preserve toast background on hover

### DIFF
--- a/packages/hub-ui/src/client/components/display/ToastOverlay.vue
+++ b/packages/hub-ui/src/client/components/display/ToastOverlay.vue
@@ -54,10 +54,10 @@ function dispatchAction(action: DevframeMessageAction) {
       <div
         v-for="toast of toasts"
         :key="toast.id"
-        class="bg-glass:80 border color-base border-base shadow-xl cursor-pointer transition-colors rounded"
+        class="bg-glass:80 border color-base border-base shadow-xl cursor-pointer hover:bg-glass:90 transition-colors rounded"
         @click="openMessages(toast.id)"
       >
-        <MessageItem :entry="toast.entry" compact class="px-3 py-2.5 hover:bg-active">
+        <MessageItem :entry="toast.entry" compact class="px-3 py-2.5">
           <template #actions>
             <button
               v-for="action of toast.entry.actions"

--- a/packages/hub-ui/src/client/components/display/ToastOverlay.vue
+++ b/packages/hub-ui/src/client/components/display/ToastOverlay.vue
@@ -54,10 +54,10 @@ function dispatchAction(action: DevframeMessageAction) {
       <div
         v-for="toast of toasts"
         :key="toast.id"
-        class="bg-glass:80 border color-base border-base shadow-xl cursor-pointer hover:bg-active transition-colors rounded"
+        class="bg-glass:80 border color-base border-base shadow-xl cursor-pointer transition-colors rounded"
         @click="openMessages(toast.id)"
       >
-        <MessageItem :entry="toast.entry" compact class="px-3 py-2.5">
+        <MessageItem :entry="toast.entry" compact class="px-3 py-2.5 hover:bg-active">
           <template #actions>
             <button
               v-for="action of toast.entry.actions"

--- a/packages/hub-ui/src/client/components/display/ToastOverlay.vue
+++ b/packages/hub-ui/src/client/components/display/ToastOverlay.vue
@@ -54,7 +54,7 @@ function dispatchAction(action: DevframeMessageAction) {
       <div
         v-for="toast of toasts"
         :key="toast.id"
-        class="bg-glass:80 border color-base border-base shadow-xl cursor-pointer hover:bg-glass:90 transition-colors rounded"
+        class="bg-toast-glass border color-base border-base shadow-xl cursor-pointer transition-colors rounded"
         @click="openMessages(toast.id)"
       >
         <MessageItem :entry="toast.entry" compact class="px-3 py-2.5">

--- a/packages/hub-ui/uno.config.ts
+++ b/packages/hub-ui/uno.config.ts
@@ -26,6 +26,8 @@ export default mergeConfigs([
     shortcuts: {
       /** Use the lighter glass in light mode while retaining dark-mode contrast. */
       'bg-dock-glass': 'bg-glass dark:bg-[#111]/80',
+      /** Match dock glass at rest, then strengthen each theme slightly on hover. */
+      'bg-toast-glass': 'bg-dock-glass hover:bg-white/78 dark:hover:bg-[#111]/90',
       // Dock-shell z-layers (named — the design preset blocks plain
       // `z-<number>`). The floating shell layers sit at the very top of the
       // host page's stacking order, mirroring the upstream dock.


### PR DESCRIPTION
## Summary

- keep the toast background, hover state, rounded corners, and color transition on the outer toast element
- match the dock's `bg-dock-glass` material at rest through a `bg-toast-glass` shortcut
- strengthen that material on hover without replacing it: 65% to 78% opacity in light mode, and 80% to 90% in dark mode

## Before / after

Both screenshots show the upstream `messages-toastoverlay--with-action` Storybook story in dark mode while hovered.

| Before | After |
| --- | --- |
| `hover:bg-active` replaces the dark glass surface with a lightly tinted transparent background. | The rounded root keeps the dark glass surface and transitions from 80% to 90% opacity. |
| <img width="380" height="140" alt="Toast hover before: glass background is replaced" src="https://github.com/user-attachments/assets/ed021a96-ef96-4317-80dc-872a3856bfc1" /> | <img width="380" height="140" alt="Toast hover after: the root keeps its dark glass background" src="https://github.com/user-attachments/assets/0673a658-6c94-4eba-9ed2-cf434d6256d8" /> |

## Theme regression check

These screenshots show the upstream `messages-toastoverlay--stack` story with the pointer over the first toast. The toast uses the same resting material as the dock in each theme.

| Light hover | Dark hover |
| --- | --- |
| `rgba(255, 255, 255, 0.78)` | `rgba(17, 17, 17, 0.9)` |
| <img width="336" height="208" alt="Light-theme toast stack with the first toast hovered" src="https://github.com/user-attachments/assets/760f0216-d148-43d9-b841-4c629d31f0ab" /> | <img width="336" height="208" alt="Dark-theme toast stack with the first toast hovered" src="https://github.com/user-attachments/assets/5a3e2353-8627-402a-87d3-7c7a680e6f2b" /> |

## Validation

- `pnpm --filter @devframes/hub-ui build`
- `pnpm --filter @devframes/hub-ui typecheck`
- `pnpm exec eslint packages/hub-ui/uno.config.ts packages/hub-ui/src/client/components/display/ToastOverlay.vue`
- `pnpm exec vitest run packages/hub-ui/src` (32 passed)
- Storybook hover checked in light and dark modes
- computed light background changes from `rgba(255, 255, 255, 0.65)` to `rgba(255, 255, 255, 0.78)`
- computed dark background changes from `rgba(17, 17, 17, 0.8)` to `rgba(17, 17, 17, 0.9)`
