### PR TITLE
feat(hub): add configurable iframe navigation controls

### DIFF
--- a/docs/content/8.references/6.hub-api.md
+++ b/docs/content/8.references/6.hub-api.md
@@ -137,7 +137,7 @@ The built-in variants of the open dock union (`DevframeDockEntryRegistry`, `@dev
 
 | Type | The hub UI provider renders |
 |---|---|
-| `iframe` | the entry's `url` in a kept-alive iframe (per `frameId` when shared); honor `subTabs` soft nav; force the existing address bar with `showAddressBar`; override Back, Reload, and Open externally visibility with `controls.back`, `controls.reload`, and `controls.openExternal` |
+| `iframe` | the entry's `url` in a kept-alive iframe (per `frameId` when shared); honor `subTabs` soft nav; show the existing address bar with `addressBar: true`, or configure Back, Reload, and Open externally by passing an `addressBar` object |
 | `action` | a dock-rail button; activating runs its client script |
 | `custom-render` | a container its client script mounts into |
 | `launcher` | a launch call-to-action reflecting `launcher.status` |

--- a/docs/content/8.references/6.hub-api.md
+++ b/docs/content/8.references/6.hub-api.md
@@ -137,7 +137,7 @@ The built-in variants of the open dock union (`DevframeDockEntryRegistry`, `@dev
 
 | Type | The hub UI provider renders |
 |---|---|
-| `iframe` | the entry's `url` in a kept-alive iframe (per `frameId` when shared); honor `subTabs` soft nav |
+| `iframe` | the entry's `url` in a kept-alive iframe (per `frameId` when shared); honor `subTabs` soft nav; force the existing address bar with `showAddressBar`; override Back, Reload, and Open externally visibility with `controls.back`, `controls.reload`, and `controls.openExternal` |
 | `action` | a dock-rail button; activating runs its client script |
 | `custom-render` | a container its client script mounts into |
 | `launcher` | a launch call-to-action reflecting `launcher.status` |

--- a/packages/hub-ui/src/client/components/views-builtin/SettingsAppearance.vue
+++ b/packages/hub-ui/src/client/components/views-builtin/SettingsAppearance.vue
@@ -106,7 +106,7 @@ function setDockMode(mode: string) {
       </button>
       <div class="flex flex-col">
         <span class="text-sm">Always show iframe address bars</span>
-        <span class="text-xs op50">Show the address bar for every iframe dock. When disabled, only docks that request it show one.</span>
+        <span class="text-xs op50">Show the address bar for every iframe dock.</span>
       </div>
     </label>
 

--- a/packages/hub-ui/src/client/components/views-builtin/SettingsAppearance.vue
+++ b/packages/hub-ui/src/client/components/views-builtin/SettingsAppearance.vue
@@ -105,8 +105,8 @@ function setDockMode(mode: string) {
         />
       </button>
       <div class="flex flex-col">
-        <span class="text-sm">Show iframe address bar</span>
-        <span class="text-xs op50">Display navigation controls and URL bar for iframe views</span>
+        <span class="text-sm">Always show iframe address bars</span>
+        <span class="text-xs op50">Show the address bar for every iframe dock. When disabled, only docks that request it show one.</span>
       </div>
     </label>
 

--- a/packages/hub-ui/src/client/components/views/ViewIframe.vue
+++ b/packages/hub-ui/src/client/components/views/ViewIframe.vue
@@ -20,7 +20,8 @@ const props = defineProps<{
 
 const settings = useSettings(props.context)
 const isEdgeMode = computed(() => props.context.panel.store.mode === 'edge')
-const showAddressBar = computed(() => settings.value.showIframeAddressBar || props.entry.showAddressBar === true)
+const addressBarControls = computed(() => typeof props.entry.addressBar === 'object' ? props.entry.addressBar : undefined)
+const showAddressBar = computed(() => settings.value.showIframeAddressBar || Boolean(props.entry.addressBar))
 
 const ADDRESS_BAR_HEIGHT = 40
 
@@ -83,9 +84,9 @@ const isCrossOrigin = computed(() => {
     return true // Assume cross-origin if URL parsing fails
   }
 })
-const showBack = computed(() => props.entry.controls?.back ?? !isCrossOrigin.value)
-const showReload = computed(() => props.entry.controls?.reload ?? !isCrossOrigin.value)
-const showOpenExternal = computed(() => props.entry.controls?.openExternal ?? false)
+const showBack = computed(() => addressBarControls.value?.back ?? !isCrossOrigin.value)
+const showReload = computed(() => addressBarControls.value?.reload ?? !isCrossOrigin.value)
+const showOpenExternal = computed(() => addressBarControls.value?.openExternal ?? false)
 
 // Display URL - hides host if same as current page. The remote connection
 // descriptor is stripped so its auth token can't be read (or copied) out of the

--- a/packages/hub-ui/src/client/components/views/ViewIframe.vue
+++ b/packages/hub-ui/src/client/components/views/ViewIframe.vue
@@ -20,7 +20,7 @@ const props = defineProps<{
 
 const settings = useSettings(props.context)
 const isEdgeMode = computed(() => props.context.panel.store.mode === 'edge')
-const showAddressBar = computed(() => settings.value.showIframeAddressBar)
+const showAddressBar = computed(() => settings.value.showIframeAddressBar || props.entry.showAddressBar === true)
 
 const ADDRESS_BAR_HEIGHT = 40
 
@@ -77,13 +77,15 @@ const currentPageOrigin = computed(() => {
 // Check if iframe URL is cross-origin
 const isCrossOrigin = computed(() => {
   try {
-    const url = new URL(currentUrl.value)
-    return url.origin !== currentPageOrigin.value
+    return new URL(currentUrl.value).origin !== currentPageOrigin.value
   }
   catch {
     return true // Assume cross-origin if URL parsing fails
   }
 })
+const showBack = computed(() => props.entry.controls?.back ?? !isCrossOrigin.value)
+const showReload = computed(() => props.entry.controls?.reload ?? !isCrossOrigin.value)
+const showOpenExternal = computed(() => props.entry.controls?.openExternal ?? false)
 
 // Display URL - hides host if same as current page. The remote connection
 // descriptor is stripped so its auth token can't be read (or copied) out of the
@@ -189,10 +191,20 @@ function refresh() {
 
   assetsError.value = null
   isIframeLoading.value = true
-  // Reload by reassigning the src
   const src = iframe.src
   iframe.src = ''
   iframe.src = src
+  currentUrl.value = src
+  editingUrl.value = src
+}
+
+function openExternally() {
+  try {
+    const url = new URL(stripRemoteConnectionFromUrl(currentUrl.value))
+    if (url.protocol === 'http:' || url.protocol === 'https:')
+      window.open(url.href, '_blank', 'noopener,noreferrer')
+  }
+  catch {}
 }
 
 let onIframeLoad: (() => void) | undefined
@@ -322,39 +334,36 @@ onUnmounted(() => {
   <div class="w-full h-full flex flex-col">
     <div
       v-if="showAddressBar"
-      class="flex-none px-2 w-full flex items-center gap-1 border-base border-b"
+      class="flex-none px-2 w-full flex items-center gap-1 color-base border-base border-b"
       :style="{ height: `${ADDRESS_BAR_HEIGHT}px` }"
     >
-      <!-- Navigation buttons (hidden for cross-origin) -->
-      <template v-if="!isCrossOrigin">
-        <!-- Back button -->
-        <button
-          class="w-7 h-7 flex items-center justify-center rounded hover:bg-gray/15 transition-colors shrink-0"
-          title="Back"
-          @click="goBack"
-        >
-          <div class="i-ph-caret-left op60 w-4.5 h-4.5" />
-        </button>
-
-        <!-- Refresh button -->
-        <button
-          class="w-7 h-7 flex items-center justify-center rounded hover:bg-gray/15 transition-colors shrink-0"
-          title="Refresh"
-          @click="refresh"
-        >
-          <div class="i-ph-arrow-clockwise op60 w-4.5 h-4.5" />
-        </button>
-      </template>
+      <button
+        v-if="showBack"
+        class="w-7 h-7 flex items-center justify-center rounded hover:bg-gray/15 transition-colors shrink-0"
+        title="Back"
+        @click="goBack"
+      >
+        <div class="i-ph-caret-left op60 w-4.5 h-4.5" />
+      </button>
 
       <!-- Cross-origin badge -->
       <div
-        v-else
+        v-if="isCrossOrigin"
         class="flex items-center gap-1 px2 py1 rounded text-xs bg-amber/10 text-amber border border-amber/20 shrink-0"
-        title="Cross-origin iframe - navigation controls unavailable"
+        title="Cross-origin iframe"
       >
         <div class="i-ph-globe text-sm" />
         <span>Cross-Origin</span>
       </div>
+
+      <button
+        v-if="showReload"
+        class="w-7 h-7 flex items-center justify-center rounded hover:bg-gray/15 transition-colors shrink-0"
+        title="Reload"
+        @click="refresh"
+      >
+        <div class="i-ph-arrow-clockwise op60 w-4.5 h-4.5" />
+      </button>
 
       <!-- URL input -->
       <div class="flex-1 flex items-center h-7 px-2.5 rounded bg-gray/5 border border-transparent hover:border-gray/10 focus-within:border-gray/15 transition-colors">
@@ -376,6 +385,15 @@ onUnmounted(() => {
           class="i-ph-circle-notch text-sm op40 ml-2 shrink-0 animate-spin"
         />
       </div>
+
+      <button
+        v-if="showOpenExternal"
+        class="w-7 h-7 flex items-center justify-center rounded hover:bg-gray/15 transition-colors shrink-0"
+        title="Open externally"
+        @click="openExternally"
+      >
+        <div class="i-ph-arrow-square-out-duotone op60 w-4.5 h-4.5" />
+      </button>
     </div>
     <div
       ref="viewFrame"

--- a/packages/hub-ui/src/client/components/views/ViewIframe.vue
+++ b/packages/hub-ui/src/client/components/views/ViewIframe.vue
@@ -191,7 +191,7 @@ function refresh() {
 
   assetsError.value = null
   isIframeLoading.value = true
-  const src = iframe.src
+  const src = currentUrl.value
   iframe.src = ''
   iframe.src = src
   currentUrl.value = src

--- a/packages/hub-ui/src/client/components/views/ViewIframeLoading.vue
+++ b/packages/hub-ui/src/client/components/views/ViewIframeLoading.vue
@@ -1,12 +1,10 @@
 <script setup lang="ts">
-// Placeholder shown while an iframe view loads its content. A blank iframe
-// paints white during load, so this is only visible once the pane steps aside
-// (`pane.hide()` in `ViewIframe`) — the same layering trick `ViewAssetsError`
-// relies on. It covers the initial load and any hard navigation/refresh.
+// Placeholder shown while an iframe view loads its content. The pane steps
+// aside while loading so this inherits the viewer's configured background.
 </script>
 
 <template>
-  <div class="devframes-view-iframe-loading absolute inset-0 flex flex-col items-center justify-center gap-2 bg-base">
+  <div class="devframes-view-iframe-loading absolute inset-0 flex flex-col items-center justify-center gap-2">
     <div class="i-ph:circle-notch-duotone animate-spin text-3xl color-faint" />
     <div class="text-sm color-muted">
       Loading…

--- a/packages/hub/src/types/docks.ts
+++ b/packages/hub/src/types/docks.ts
@@ -203,15 +203,13 @@ declare module 'devframe/types' {
 export interface DevframeViewIframe extends DevframeDockEntryBase {
   type: 'iframe'
   url: string
-  /** Request the address bar for this iframe dock. The user's global always-show setting forces it on for every iframe. */
-  showAddressBar?: boolean
-  /** Optional address-bar controls. Omitted values retain the existing origin-based behavior. */
-  controls?: {
+  /** Request the address bar for this iframe dock. Pass an object to configure its controls. The user's global always-show setting forces it on for every iframe. */
+  addressBar?: boolean | {
     /** Override Back visibility. Cross-origin history access may still be blocked by the browser. */
     back?: boolean
     /** Override Reload visibility. */
     reload?: boolean
-    /** Override the built-in action that opens the displayed HTTP(S) URL in a new tab. */
+    /** Override Open externally visibility. */
     openExternal?: boolean
   }
   /**

--- a/packages/hub/src/types/docks.ts
+++ b/packages/hub/src/types/docks.ts
@@ -203,7 +203,7 @@ declare module 'devframe/types' {
 export interface DevframeViewIframe extends DevframeDockEntryBase {
   type: 'iframe'
   url: string
-  /** Show the iframe address bar regardless of the user's global setting. */
+  /** Request the address bar for this iframe dock. The user's global always-show setting forces it on for every iframe. */
   showAddressBar?: boolean
   /** Optional address-bar controls. Omitted values retain the existing origin-based behavior. */
   controls?: {

--- a/packages/hub/src/types/docks.ts
+++ b/packages/hub/src/types/docks.ts
@@ -203,6 +203,17 @@ declare module 'devframe/types' {
 export interface DevframeViewIframe extends DevframeDockEntryBase {
   type: 'iframe'
   url: string
+  /** Show the iframe address bar regardless of the user's global setting. */
+  showAddressBar?: boolean
+  /** Optional address-bar controls. Omitted values retain the existing origin-based behavior. */
+  controls?: {
+    /** Override Back visibility. Cross-origin history access may still be blocked by the browser. */
+    back?: boolean
+    /** Override Reload visibility. */
+    reload?: boolean
+    /** Override the built-in action that opens the displayed HTTP(S) URL in a new tab. */
+    openExternal?: boolean
+  }
   /**
    * The id of the iframe, if multiple tabs is assigned with the same id, the iframe will be shared.
    *

--- a/tests/__snapshots__/tsnapi/@devframes/hub/index.snapshot.d.ts
+++ b/tests/__snapshots__/tsnapi/@devframes/hub/index.snapshot.d.ts
@@ -293,8 +293,7 @@ export interface DevframeViewGroup extends DevframeDockEntryBase {
 export interface DevframeViewIframe extends DevframeDockEntryBase {
   type: 'iframe';
   url: string;
-  showAddressBar?: boolean;
-  controls?: {
+  addressBar?: boolean | {
     back?: boolean;
     reload?: boolean;
     openExternal?: boolean;

--- a/tests/__snapshots__/tsnapi/@devframes/hub/index.snapshot.d.ts
+++ b/tests/__snapshots__/tsnapi/@devframes/hub/index.snapshot.d.ts
@@ -293,6 +293,12 @@ export interface DevframeViewGroup extends DevframeDockEntryBase {
 export interface DevframeViewIframe extends DevframeDockEntryBase {
   type: 'iframe';
   url: string;
+  showAddressBar?: boolean;
+  controls?: {
+    back?: boolean;
+    reload?: boolean;
+    openExternal?: boolean;
+  };
   frameId?: string;
   clientScript?: ClientScriptEntry;
   navTarget?: NavTarget;


### PR DESCRIPTION
## Background (Why)

Iframe dock entries currently rely on global address-bar visibility and same-origin navigation detection. Consumers embedding cross-origin tools need a small, generic way to expose recovery controls when an iframe cannot complete a flow in place, while existing dock behavior must remain unchanged by default.

## Changes (What)

Iframe entries can now show the existing address bar with `addressBar: true`, or pass an `addressBar` object to configure Back, Reload, and Open externally. The global always-show preference continues to show the address bar for every iframe. Omitted Back and Reload values preserve the same-origin defaults, while Open externally remains disabled unless explicitly enabled. Reload restores the configured iframe URL; Open externally accepts HTTP(S) URLs, removes the remote-auth descriptor, and opens with `noopener,noreferrer`.

The existing iframe reference and mounted event remain the integration points. This change adds no navigation-reporting state, events, RPC, authentication handling, or custom action framework. The toolbar now uses the semantic foreground color in light theme, and the loading view inherits the viewer background instead of layering another translucent fill.

## Note for maintainers

The cross-origin playground fixture exposed an existing cleanup issue in `frame-location`. The location watcher subscribes to a same-origin iframe window, but after that iframe navigates cross-origin, its load or teardown path invokes the captured disposer and attempts to call `removeEventListener` on the now-cross-origin window. The browser blocks that access and reports a non-fatal `SecurityError`.

This behavior predates the configurable controls and fixing it requires a separate change to the frame-location listener lifecycle, so it is deliberately outside this PR's configuration and styling scope. I can follow up with that fix separately if useful.

## Verification (Testing)

The build, type checking, lint, unused-code checks, and public API snapshot test passed. A full repository run reached 1,320 passing tests and 9 skipped; seven unrelated process and filesystem timing tests failed, and the three failures that persisted in isolation reproduced on the exact base commit. I manually exercised Back, Reload, and Open externally in the `@devframes/hub-ui` playground with a temporary generic `https://example.com/` iframe fixture; the fixture is not included in this PR.

### Light theme

<img width="1440" height="900" alt="Devframes hub-ui playground showing configurable iframe controls in light theme" src="https://github.com/user-attachments/assets/82734eb2-12b1-4fa6-b968-10046b401598" />

### Dark theme

<img width="1440" height="900" alt="Devframes hub-ui playground showing configurable iframe controls in dark theme" src="https://github.com/user-attachments/assets/288da4f1-7200-40cd-82bd-624b59feb479" />
