### PR TITLE
fix(code-server): make launcher scrollable

### DIFF
--- a/plugins/code-server/app/components/LauncherView.stories.ts
+++ b/plugins/code-server/app/components/LauncherView.stories.ts
@@ -46,6 +46,16 @@ export const NotInstalled: Story = {
   },
 }
 
+/** Short dock panel with install instructions available through scrolling. */
+export const NotInstalledShortPanel: Story = {
+  args: NotInstalled.args,
+  render: args => ({
+    components: { LauncherView },
+    setup: () => ({ args }),
+    template: '<div class="relative h-64 overflow-hidden"><LauncherView v-bind="args" /></div>',
+  }),
+}
+
 /** Installed and idle, showing the launch screen (code-server backend). */
 export const Launch: Story = {
   args: {

--- a/plugins/code-server/app/components/LauncherView.vue
+++ b/plugins/code-server/app/components/LauncherView.vue
@@ -46,8 +46,8 @@ const errorText = computed(() => (props.server.status === 'error' ? props.server
 </script>
 
 <template>
-  <div class="absolute inset-0 flex items-center justify-center p-6 bg-base color-base font-sans">
-    <div class="w-full max-w-[560px]">
+  <div class="absolute inset-0 flex of-y-auto p-6 box-border bg-base color-base font-sans">
+    <div class="m-auto w-full max-w-[560px]">
       <!-- Brand eyebrow -->
       <p class="flex items-center gap-1.5 mb-2.5 text-xs tracking-wider uppercase color-muted">
         <span class="i-ph-code-duotone text-sm" />


### PR DESCRIPTION
## Summary

- make the Code Server launcher scroll when the dock panel is shorter than its content
- preserve vertical centering when the panel has enough height
- add a short-panel Storybook regression scenario

## Verification

- pnpm lint
- pnpm knip
- pnpm test
- pnpm typecheck
- pnpm build
- pnpm -C plugins/code-server run build-storybook
- manually verified scrolling and centered layout in the Hub Vite playground