### PR TITLE
fix(code-server): open external links in new tabs

### DIFF
--- a/plugins/code-server/app/components/LauncherView.stories.ts
+++ b/plugins/code-server/app/components/LauncherView.stories.ts
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
 import type { CodeServerDetection } from '../connect'
+import { expect, within } from 'storybook/test'
 import LauncherView from './LauncherView.vue'
 
 const localCodeServer: CodeServerDetection = {
@@ -43,6 +44,18 @@ export const NotInstalled: Story = {
     detection: { checked: true, installed: false, bin: 'code-server', backend: 'code-server', mode: 'local' },
     server: { status: 'stopped' },
     busy: false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const docsLink = canvas.getByRole('link', { name: 'Installation docs' })
+    const repoLink = canvas.getByRole('link', { name: 'GitHub' })
+
+    await expect(docsLink).toHaveAttribute('href', 'https://coder.com/docs/code-server/latest/install')
+    await expect(docsLink).toHaveAttribute('target', '_blank')
+    await expect(docsLink).toHaveAttribute('rel', 'noreferrer')
+    await expect(repoLink).toHaveAttribute('href', 'https://github.com/coder/code-server')
+    await expect(repoLink).toHaveAttribute('target', '_blank')
+    await expect(repoLink).toHaveAttribute('rel', 'noreferrer')
   },
 }
 

--- a/plugins/code-server/app/components/LauncherView.vue
+++ b/plugins/code-server/app/components/LauncherView.vue
@@ -130,10 +130,24 @@ const errorText = computed(() => (props.server.status === 'error' ? props.server
           >
             {{ busy ? 'Checking…' : 'Re-check' }}
           </ActionButton>
-          <ActionButton variant="text" size="sm" :href="DOCS_URL" icon="i-ph-arrow-square-out">
+          <ActionButton
+            variant="text"
+            size="sm"
+            :href="DOCS_URL"
+            target="_blank"
+            rel="noreferrer"
+            icon="i-ph-arrow-square-out"
+          >
             Installation docs
           </ActionButton>
-          <ActionButton variant="text" size="sm" :href="REPO_URL" icon="i-ph-github-logo">
+          <ActionButton
+            variant="text"
+            size="sm"
+            :href="REPO_URL"
+            target="_blank"
+            rel="noreferrer"
+            icon="i-ph-github-logo"
+          >
             GitHub
           </ActionButton>
         </div>


### PR DESCRIPTION
## Problem

The Code Server launcher opened its Installation docs and GitHub links inside the embedded iframe. Both destinations reject framing, replacing the launcher with a browser error page.

## Cause

The two external ActionButton links did not specify a target, so browser navigation reused the iframe browsing context.

## Fix

- Open both external resources in a new tab with target="_blank" and rel="noreferrer".
- Add Storybook play assertions covering each link URL, target, and rel attribute.

## Verification

- `pnpm lint`
- `pnpm knip`
- `pnpm test` — 127 test files passed; 1,452 tests passed and 9 skipped
- `pnpm typecheck` — typecheck coverage passed; 39/39 tasks passed
- `pnpm build` — 27/27 tasks passed
- Browser validation in the embedded Hub: both links opened new top-level tabs while the Hub and Code Server panel remained open