### PR TITLE
fix(a11y): keep summary above scrolled violations

### DIFF
--- a/plugins/a11y/app/components/SummaryBar.tsx
+++ b/plugins/a11y/app/components/SummaryBar.tsx
@@ -38,7 +38,7 @@ const ACTION = 'inline-flex items-center gap-1.5 text-xs color-muted bg-secondar
 export function SummaryBar(props: SummaryBarProps) {
   const plural = (n: number, one: string) => `${n} ${n === 1 ? one : `${one}s`}`
   return (
-    <div class="flex flex-col gap-2 pt-3 pb-2.5 sticky top-0 z-[2] bg-base">
+    <div class="flex flex-col gap-2 pt-3 pb-2.5 sticky top-0 z-nav bg-base">
       <Summary counts={props.counts} active={props.filter} onToggle={props.onToggleFilter} onHover={props.onHoverImpact} />
 
       <div class="flex items-center gap-2 flex-wrap">

--- a/tests/e2e/a11y-messages-hub-static.spec.ts
+++ b/tests/e2e/a11y-messages-hub-static.spec.ts
@@ -34,6 +34,32 @@ test.describe('a11y-messages playground (static hub build)', () => {
     await expect(page.locator('[data-df-a11y-overlay]')).toContainText('image-alt')
   })
 
+  test('keeps the a11y summary controls above scrolled violations', async ({ page }) => {
+    await page.setViewportSize({ width: 1_000, height: 360 })
+    const panel = page.frameLocator('iframe[title="A11y Inspector"]')
+
+    await expect(panel.getByRole('checkbox', { name: /image-alt/ })).toBeVisible()
+    const scrollArea = panel.locator('#a11y-scroll')
+    const summary = scrollArea.locator(':scope > div').first()
+    await scrollArea.evaluate(element => element.scrollTo({ top: element.scrollHeight }))
+
+    expect(await scrollArea.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+    expect(await summary.locator('button').evaluateAll(buttons => buttons.flatMap((button) => {
+      const bounds = button.getBoundingClientRect()
+      const hitTarget = document.elementFromPoint(
+        bounds.left + bounds.width / 2,
+        bounds.top + bounds.height / 2,
+      )
+      return hitTarget != null && button.contains(hitTarget)
+        ? []
+        : [button.getAttribute('aria-label') ?? button.title ?? button.textContent?.trim()]
+    }))).toEqual([])
+
+    const critical = panel.getByRole('button', { name: /Critical issues/ })
+    await critical.click()
+    await expect(critical).toHaveAttribute('aria-pressed', 'true')
+  })
+
   test('messages panel renders the baked feed; its activate action switches docks over the BroadcastChannel', async ({ page }) => {
     await page.click('button[data-dock-id="devframes_plugin_messages"]')
     const panel = page.frameLocator('iframe[title="Messages"]')


### PR DESCRIPTION
## Problem

In a short A11y Inspector dock, scrolling the violation list could paint violation rows over the sticky summary controls. This left the summary partially visible but made its lower actions inaccessible.

## Cause

The summary used `z-[2]`, but the shared `@antfu/design` UnoCSS preset blocks unnamed numeric z-index utilities. The class therefore produced no z-index rule, allowing later positioned violation rows to paint above the sticky summary.

## Fix

Use the shared `z-nav` layer for the sticky summary. Add a 360px-height regression test that scrolls the panel, verifies every summary button remains the pointer hit target, and confirms a severity filter is still interactive.

## Verification

- `pnpm lint`
- `pnpm knip`
- `pnpm typecheck` — 39/39 tasks passed
- `pnpm test` — 128 files passed; 1,453 tests passed and 9 skipped; no type errors
- `pnpm build` — 27/27 tasks passed
- `pnpm exec playwright test --config .tmp-playwright.config.ts tests/e2e/a11y-messages-hub-static.spec.ts` — 4/4 tests passed using the installed system Chrome