### PR TITLE
feat: add runtime in-page channel events

### DIFF
--- a/docs/content/1.guide/12.in-page-channel.md
+++ b/docs/content/1.guide/12.in-page-channel.md
@@ -54,7 +54,7 @@ Channel names are namespaced with the devframe id, like RPC ids. Function names 
 
 ## The page script endpoint
 
-Request/response functions use the same authoring metadata as `defineRpcFunction` (`type`, Standard-Schema `args`/`returns`, `jsonSerializable`, `handler`), narrowed to the browser. The optional `functions` object registers initial handlers, while `channel.on()` subscribes event listeners at runtime. Each handler is contextually typed from its key and the corresponding function in the protocol. `defineChannelFunction` retains the named definition shape for lower-level authoring. Define each side's functions in that side's source files; the shared protocol file carries only types.
+The required `functions` object declares every function on that endpoint's protocol side, preserving a compile-time completeness check. Request/response declarations require a `handler`; an event declaration uses `type: 'event'` and may receive events through either its optional `handler` or runtime `channel.on()` listeners. Functions use the same Standard-Schema `args`/`returns` and `jsonSerializable` metadata as `defineRpcFunction`, narrowed to the browser. Each handler is contextually typed from its key and the corresponding protocol function. `defineChannelFunction` retains the named definition shape for lower-level authoring. Define each side's functions in that side's source files; the shared protocol file carries only types.
 
 ```ts
 import type { MyChannelProtocol } from '../shared/protocol'
@@ -96,6 +96,9 @@ import { MY_CHANNEL } from '../shared/protocol'
 
 const channel = connectPanelChannel<MyChannelProtocol>({
   name: MY_CHANNEL,
+  functions: {
+    flash: { type: 'event' },
+  },
 })
 
 const offFlash = channel.on('flash', message => showFlash(message))

--- a/docs/content/1.guide/12.in-page-channel.md
+++ b/docs/content/1.guide/12.in-page-channel.md
@@ -37,11 +37,11 @@ import type { InPageChannelProtocol } from 'devframe/in-page-channel'
 export const MY_CHANNEL = 'devframes:plugin:my-tool'
 
 export interface MyChannelProtocol extends InPageChannelProtocol {
-  pageScript: { // implemented by the page script, called by panels
+  pageScript: { // functions and events received by the page script
     highlight: (selector: string) => void
     measure: (selector: string) => { width: number, height: number }
   }
-  panel: { // implemented by panels, called by the page script
+  panel: { // functions and events received by panels
     flash: (message: string) => void
   }
   sharedStates: {
@@ -54,7 +54,7 @@ Channel names are namespaced with the devframe id, like RPC ids. Function names 
 
 ## The page script endpoint
 
-Functions use the same authoring metadata as `defineRpcFunction` (`type`, Standard-Schema `args`/`returns`, `jsonSerializable`, `handler`), narrowed to the browser. The required `functions` object's keys are the function names, and it implements every function on that endpoint's protocol side. Each handler is contextually typed from its key and the corresponding function in the protocol. `defineChannelFunction` retains the named definition shape for lower-level authoring. Define each side's functions in that side's source files; the shared protocol file carries only types.
+Request/response functions use the same authoring metadata as `defineRpcFunction` (`type`, Standard-Schema `args`/`returns`, `jsonSerializable`, `handler`), narrowed to the browser. The optional `functions` object registers initial handlers, while `channel.on()` subscribes event listeners at runtime. Each handler is contextually typed from its key and the corresponding function in the protocol. `defineChannelFunction` retains the named definition shape for lower-level authoring. Define each side's functions in that side's source files; the shared protocol file carries only types.
 
 ```ts
 import type { MyChannelProtocol } from '../shared/protocol'
@@ -79,12 +79,12 @@ const channel = createPageScriptChannel<MyChannelProtocol>({
   },
 })
 
-channel.callEvent('flash', 'scanning…') // fans out to every connected panel
+channel.emit('flash', 'scanning…') // fans out to every connected panel
 channel.events.on('panel:connected', panel => console.log(panel.id))
 channel.events.on('panel:disconnected', () => pauseWorkIfNobodyWatches())
 ```
 
-`callEvent` on the page script is 1:N: it fans out to every connected panel, and panels that don't implement the function ignore it. Request/response *to* a panel goes through an explicit peer handle: `channel.panels[0].call('flash', '…')`.
+`emit` on the page script is 1:N: it fans out to every connected panel. Request/response *to* a panel goes through an explicit peer handle: `channel.panels[0].call('flash', '…')`.
 
 ## The panel endpoint
 
@@ -96,15 +96,13 @@ import { MY_CHANNEL } from '../shared/protocol'
 
 const channel = connectPanelChannel<MyChannelProtocol>({
   name: MY_CHANNEL,
-  functions: {
-    flash: {
-      handler: message => showFlash(message),
-    },
-  },
 })
 
-channel.callEvent('highlight', '.hero') // buffered until connected
+const offFlash = channel.on('flash', message => showFlash(message))
+channel.emit('highlight', '.hero') // buffered until connected
 const size = await channel.call('measure', '.hero')
+
+offFlash() // stop listening
 ```
 
 ## Shared state
@@ -133,7 +131,7 @@ Every failure mode is a coded `InPageChannelError` (`error.code`) with a message
 The panel endpoint's connection lifecycle is explicit, so a panel renders a useful fallback instead of hanging:
 
 - `channel.status` is `connecting` → `connected` → (`connecting` on port loss) → `closed`, with `events.on('status:updated', …)` for reactivity.
-- While `connecting`, `call()` is queued (and still subject to its deadline) and `callEvent()` is buffered (up to `eventBufferLimit`, oldest dropped with a warning); both flush on connect.
+- While `connecting`, `call()` is queued (and still subject to its deadline) and `emit()` is buffered (up to `eventBufferLimit`, oldest dropped with a warning); both flush on connect.
 - A page script may legitimately never appear (the panel opened standalone, the user app not instrumented). Race `whenConnected(timeoutMs)` to show a "load the page script" empty state:
 
 ```ts

--- a/docs/content/1.guide/12.in-page-channel.md
+++ b/docs/content/1.guide/12.in-page-channel.md
@@ -54,7 +54,7 @@ Channel names are namespaced with the devframe id, like RPC ids. Function names 
 
 ## The page script endpoint
 
-The required `functions` object declares every function on that endpoint's protocol side, preserving a compile-time completeness check. Request/response declarations require a `handler`; an event declaration uses `type: 'event'` and may receive events through either its optional `handler` or runtime `channel.on()` listeners. Functions use the same Standard-Schema `args`/`returns` and `jsonSerializable` metadata as `defineRpcFunction`, narrowed to the browser. Each handler is contextually typed from its key and the corresponding protocol function. `defineChannelFunction` retains the named definition shape for lower-level authoring. Define each side's functions in that side's source files; the shared protocol file carries only types.
+The required `functions` object declares every function on that endpoint's protocol side, preserving a compile-time completeness check. Request/response declarations require a `handler`; an event declaration uses `type: 'event'`, and the receiving endpoint may provide an optional `handler` or subscribe at runtime with `on()`. Functions use the same Standard-Schema `args`/`returns` and `jsonSerializable` metadata as `defineRpcFunction`, narrowed to the browser. Each handler is contextually typed from its key and the corresponding protocol function. `defineChannelFunction` retains the named definition shape for lower-level authoring. Define each side's functions in that side's source files; the shared protocol file carries only types.
 
 ```ts
 import type { MyChannelProtocol } from '../shared/protocol'
@@ -62,7 +62,7 @@ import type { MyChannelProtocol } from '../shared/protocol'
 import { createPageScriptChannel } from 'devframe/in-page-channel'
 import { MY_CHANNEL } from '../shared/protocol'
 
-const channel = createPageScriptChannel<MyChannelProtocol>({
+const pageChannel = createPageScriptChannel<MyChannelProtocol>({
   name: MY_CHANNEL,
   functions: {
     highlight: {
@@ -79,12 +79,12 @@ const channel = createPageScriptChannel<MyChannelProtocol>({
   },
 })
 
-channel.emit('flash', 'scanning…') // fans out to every connected panel
-channel.events.on('panel:connected', panel => console.log(panel.id))
-channel.events.on('panel:disconnected', () => pauseWorkIfNobodyWatches())
+pageChannel.emit('flash', 'scanning…') // received by each panel endpoint
+pageChannel.events.on('panel:connected', panel => console.log(panel.id))
+pageChannel.events.on('panel:disconnected', () => pauseWorkIfNobodyWatches())
 ```
 
-`emit` on the page script is 1:N: it fans out to every connected panel. Request/response *to* a panel goes through an explicit peer handle: `channel.panels[0].call('flash', '…')`.
+`emit` on the page-script endpoint is 1:N: it fans out to every connected panel endpoint. Request/response *to* a panel goes through an explicit peer handle: `pageChannel.panels[0].call('flash', '…')`.
 
 ## The panel endpoint
 
@@ -94,19 +94,21 @@ import type { MyChannelProtocol } from '../shared/protocol'
 import { connectPanelChannel } from 'devframe/in-page-channel'
 import { MY_CHANNEL } from '../shared/protocol'
 
-const channel = connectPanelChannel<MyChannelProtocol>({
+const panelChannel = connectPanelChannel<MyChannelProtocol>({
   name: MY_CHANNEL,
   functions: {
     flash: { type: 'event' },
   },
 })
 
-const offFlash = channel.on('flash', message => showFlash(message))
-channel.emit('highlight', '.hero') // buffered until connected
-const size = await channel.call('measure', '.hero')
+const offFlash = panelChannel.on('flash', message => showFlash(message))
+panelChannel.emit('highlight', '.hero') // received by the page-script endpoint
+const size = await panelChannel.call('measure', '.hero')
 
 offFlash() // stop listening
 ```
+
+The snippets form one channel pair: `pageChannel.emit('flash', …)` invokes `panelChannel.on('flash', …)`. In the other direction, `panelChannel.emit('highlight', …)` invokes the page-script endpoint's `highlight` handler and any matching `pageChannel.on()` listeners. An endpoint never receives its own emission.
 
 ## Shared state
 

--- a/docs/content/1.guide/12.in-page-channel.md
+++ b/docs/content/1.guide/12.in-page-channel.md
@@ -37,12 +37,12 @@ import type { InPageChannelProtocol } from 'devframe/in-page-channel'
 export const MY_CHANNEL = 'devframes:plugin:my-tool'
 
 export interface MyChannelProtocol extends InPageChannelProtocol {
-  // implemented by the page script, callable by panels
+  /** implemented by the page script, callable by panels */
   pageScript: {
     highlight: (selector: string) => void
     measure: (selector: string) => { width: number, height: number }
   }
-  // implemented by panels, callable by the page script
+  /** implemented by panels, callable by the page script */
   panel: {
     flash: (message: string) => void
   }

--- a/docs/content/1.guide/12.in-page-channel.md
+++ b/docs/content/1.guide/12.in-page-channel.md
@@ -37,11 +37,13 @@ import type { InPageChannelProtocol } from 'devframe/in-page-channel'
 export const MY_CHANNEL = 'devframes:plugin:my-tool'
 
 export interface MyChannelProtocol extends InPageChannelProtocol {
-  pageScript: { // functions and events received by the page script
+  // implemented by the page script, callable by panels
+  pageScript: {
     highlight: (selector: string) => void
     measure: (selector: string) => { width: number, height: number }
   }
-  panel: { // functions and events received by panels
+  // implemented by panels, callable by the page script
+  panel: {
     flash: (message: string) => void
   }
   sharedStates: {

--- a/docs/content/6.errors/DF0077.md
+++ b/docs/content/6.errors/DF0077.md
@@ -1,0 +1,33 @@
+---
+title: 'DF0077: In-Page Channel Function Not Registered'
+description: 'An in-page channel listener names a function that is not registered on its endpoint.'
+---
+
+## Message
+
+> In-page channel function "{name}" is not registered on this endpoint.
+
+## Cause
+
+`channel.on(name, listener)` received a name absent from that endpoint's required `functions` option. A page-script endpoint subscribes to functions declared under `pageScript`; a panel endpoint subscribes to functions declared under `panel`.
+
+## Example
+
+```ts
+const channel = connectPanelChannel<MyProtocol>({
+  name: MY_CHANNEL,
+  functions: {
+    notify: { type: 'event' },
+  },
+})
+
+channel.on('missing' as any, () => {}) // ✗ throws DF0077
+```
+
+## Fix
+
+Declare the event in the endpoint's protocol side and `functions` option, then pass that declared name to `on()`.
+
+## Source
+
+- [`packages/devframe/src/in-page-channel/internal.ts`](https://github.com/devframes/devframe/blob/main/packages/devframe/src/in-page-channel/internal.ts): `createLocalFunctionRegistry().on()` throws this when no local definition matches the listener name.

--- a/docs/content/6.errors/index.md
+++ b/docs/content/6.errors/index.md
@@ -83,6 +83,7 @@ Emitted by `devframe`: the framework-neutral host, RPC, streaming, assets, servi
 | [DF0074](/errors/DF0074) | error | JSON-Render Schema Is Asynchronous |
 | [DF0075](/errors/DF0075) | warn | No RPC Transport On This Runtime |
 | [DF0076](/errors/DF0076) | error | WebSocket Upgrade Unsupported On This Runtime |
+| [DF0077](/errors/DF0077) | error | In-Page Channel Function Not Registered |
 
 ## Hub: context & lifecycle (DF80xx)
 

--- a/docs/content/8.references/5.browser-api.md
+++ b/docs/content/8.references/5.browser-api.md
@@ -47,9 +47,9 @@ The values of `rpc.status`: [Handling connection and auth errors](/guide/client#
 
 ## In-page channel endpoints
 
-The browser-only endpoint methods of the [in-page channel](/guide/in-page-channel).
+The browser-only endpoint methods of the [in-page channel](/guide/in-page-channel). `emit()` sends to the opposite endpoint; `on()` handles events arriving from that endpoint.
 
-| Method or property | Page script | Panel |
+| Method or property | Page-script endpoint | Panel endpoint |
 |--------------------|-------------|-------|
 | `emit(name, ...args)` | Fans an event out to every connected panel. | Sends an event to the page script, buffering while connecting. |
 | `on(name, listener)` | Subscribes to events emitted by a panel. | Subscribes to events emitted by the page script. Returns an unsubscribe function. |

--- a/docs/content/8.references/5.browser-api.md
+++ b/docs/content/8.references/5.browser-api.md
@@ -2,7 +2,7 @@
 title: 'Browser-Side API'
 navigation:
   icon: i-lucide-globe
-description: 'Lookup tables for the browser side: connectDevframe options, RPC client events, connection statuses, and in-page channel error codes.'
+description: 'Lookup tables for the browser side: connectDevframe options, RPC client events, connection statuses, and in-page channels.'
 ---
 
 Lookup tables for a devframe's browser side. Each section links the guide page that teaches the concept.
@@ -44,6 +44,18 @@ The values of `rpc.status`: [Handling connection and auth errors](/guide/client#
 | `unauthorized` | Socket open, trust refused. Prompt for [authentication](/guide/client#authenticating-with-a-one-time-code). |
 | `disconnected` | Socket closed (dropped mid-session or never opened). |
 | `error` | Fatal: the socket errored or connection meta couldn't load. |
+
+## In-page channel endpoints
+
+The browser-only endpoint methods of the [in-page channel](/guide/in-page-channel).
+
+| Method or property | Page script | Panel |
+|--------------------|-------------|-------|
+| `emit(name, ...args)` | Fans an event out to every connected panel. | Sends an event to the page script, buffering while connecting. |
+| `on(name, listener)` | Subscribes to events emitted by a panel. | Subscribes to events emitted by the page script. Returns an unsubscribe function. |
+| `call(name, ...args)` | Available through a specific `PanelPeer`. | Calls a page-script function and awaits its result. |
+| `events` | Local `panel:connected` / `panel:disconnected` lifecycle events. | Local `status:updated` lifecycle event. |
+| `sharedState` | Owns the authoritative state. | Mirrors the page-script state. |
 
 ## In-page channel error codes
 

--- a/docs/content/8.references/5.browser-api.md
+++ b/docs/content/8.references/5.browser-api.md
@@ -52,7 +52,7 @@ The browser-only endpoint methods of the [in-page channel](/guide/in-page-channe
 | Method or property | Page-script endpoint | Panel endpoint |
 |--------------------|-------------|-------|
 | `emit(name, ...args)` | Fans an event out to every connected panel. | Sends an event to the page script, buffering while connecting. |
-| `on(name, listener)` | Subscribes to events emitted by a panel. | Subscribes to events emitted by the page script. Returns an unsubscribe function. |
+| `on(name, listener)` | Subscribes to events emitted by a panel. Returns an unsubscribe function. | Subscribes to events emitted by the page script. Returns an unsubscribe function. |
 | `call(name, ...args)` | Available through a specific `PanelPeer`. | Calls a page-script function and awaits its result. |
 | `events` | Local `panel:connected` / `panel:disconnected` lifecycle events. | Local `status:updated` lifecycle event. |
 | `sharedState` | Owns the authoritative state. | Mirrors the page-script state. |

--- a/docs/content/8.references/5.browser-api.md
+++ b/docs/content/8.references/5.browser-api.md
@@ -2,7 +2,7 @@
 title: 'Browser-Side API'
 navigation:
   icon: i-lucide-globe
-description: 'Lookup tables for the browser side: connectDevframe options, RPC client events, connection statuses, and in-page channels.'
+description: 'Lookup tables for the browser side: connectDevframe options, RPC client events, connection statuses, and in-page channels error codes.'
 ---
 
 Lookup tables for a devframe's browser side. Each section links the guide page that teaches the concept.

--- a/packages/devframe/src/in-page-channel/diagnostics.ts
+++ b/packages/devframe/src/in-page-channel/diagnostics.ts
@@ -1,6 +1,6 @@
 import { defineDiagnostics } from 'devframe/utils/nostics'
 
-export const diagnostics = /*#__PURE__*/ defineDiagnostics({
+export const diagnostics = /* #__PURE__ */ defineDiagnostics({
   docsBase: 'https://devfra.me/errors',
   codes: {
     DF0077: {

--- a/packages/devframe/src/in-page-channel/diagnostics.ts
+++ b/packages/devframe/src/in-page-channel/diagnostics.ts
@@ -1,0 +1,11 @@
+import { defineDiagnostics } from 'devframe/utils/nostics'
+
+export const diagnostics = /*#__PURE__*/ defineDiagnostics({
+  docsBase: 'https://devfra.me/errors',
+  codes: {
+    DF0077: {
+      why: (p: { name: string }) => `In-page channel function "${p.name}" is not registered on this endpoint.`,
+      fix: 'Declare the function in this endpoint\'s `functions` option before subscribing with `on()`.',
+    },
+  },
+})

--- a/packages/devframe/src/in-page-channel/in-page-channel.test.ts
+++ b/packages/devframe/src/in-page-channel/in-page-channel.test.ts
@@ -181,7 +181,7 @@ describe('in-page channel over bring-your-own ports', () => {
     }
   })
 
-  it('fans events out to every panel; panels without the handler ignore them', async () => {
+  it('fans events out to runtime panel listeners and supports unsubscribing', async () => {
     const a = new MessageChannel()
     const b = new MessageChannel()
     const pageScript = createPageScriptChannel<TestProtocol>({
@@ -197,23 +197,27 @@ describe('in-page channel over bring-your-own ports', () => {
       ...noHandshake,
       transport: a.port2,
       functions: {
-        ...defaultPanelFunctions,
-        notify: { type: 'event', handler: (value) => {
-          received.push(`a:${value}`)
-        } },
+        'ping-panel': defaultPanelFunctions['ping-panel'],
       },
     })
-    // Panel B deliberately has no local functions in its protocol.
+    pageScript.emit('notify', 'before-listener')
+    await new Promise(resolve => setTimeout(resolve, 20))
+    expect(received).toEqual([])
+    const offNotify = panelA.on('notify', value => received.push(`a:${value}`))
+    // Panel B deliberately has no listener for this event.
     const panelB = connectPanelChannel<InPageChannelProtocol>({
       name: 'devframes:test',
       ...noHandshake,
       transport: b.port2,
-      functions: {},
     })
     try {
       expect(pageScript.panels).toHaveLength(2)
-      pageScript.callEvent('notify', 'scan')
+      pageScript.emit('notify', 'scan')
       await until(() => received.length === 1)
+      expect(received).toEqual(['a:scan'])
+      offNotify()
+      pageScript.emit('notify', 'ignored')
+      await new Promise(resolve => setTimeout(resolve, 20))
       expect(received).toEqual(['a:scan'])
     }
     finally {
@@ -518,19 +522,15 @@ describe('in-page channel handshake', () => {
       functions: defaultPanelFunctions,
     })
     const early = panel.call('echo', 'early')
-    panel.callEvent('note', 'buffered')
+    panel.emit('note', 'buffered')
 
     const pageScript = createPageScriptChannel<TestProtocol>({
       name: 'devframes:test',
       window: asWindow(hostWin),
       heartbeat: false,
-      functions: {
-        ...defaultPageScriptFunctions,
-        note: { type: 'event', handler: (value) => {
-          noted.push(value)
-        } },
-      },
+      functions: defaultPageScriptFunctions,
     })
+    pageScript.on('note', value => noted.push(value))
     try {
       await expect(early).resolves.toBe('early')
       await until(() => noted.length === 1)

--- a/packages/devframe/src/in-page-channel/in-page-channel.test.ts
+++ b/packages/devframe/src/in-page-channel/in-page-channel.test.ts
@@ -43,12 +43,12 @@ const defaultPageScriptFunctions: NonNullable<CreatePageScriptChannelOptions<Tes
   sum: { handler: (a, b) => a + b },
   boom: { handler: () => {} },
   strict: { handler: payload => payload },
-  note: { type: 'event', handler: () => {} },
+  note: { type: 'event' },
 }
 
 const defaultPanelFunctions: NonNullable<ConnectPanelChannelOptions<TestProtocol>['functions']> = {
   'ping-panel': { handler: value => `pong:${value}` },
-  'notify': { type: 'event', handler: () => {} },
+  'notify': { type: 'event' },
 }
 
 function createLinkedPair(options?: {
@@ -196,9 +196,7 @@ describe('in-page channel over bring-your-own ports', () => {
       name: 'devframes:test',
       ...noHandshake,
       transport: a.port2,
-      functions: {
-        'ping-panel': defaultPanelFunctions['ping-panel'],
-      },
+      functions: defaultPanelFunctions,
     })
     pageScript.emit('notify', 'before-listener')
     await new Promise(resolve => setTimeout(resolve, 20))
@@ -209,6 +207,7 @@ describe('in-page channel over bring-your-own ports', () => {
       name: 'devframes:test',
       ...noHandshake,
       transport: b.port2,
+      functions: {},
     })
     try {
       expect(pageScript.panels).toHaveLength(2)

--- a/packages/devframe/src/in-page-channel/in-page-channel.test.ts
+++ b/packages/devframe/src/in-page-channel/in-page-channel.test.ts
@@ -1,5 +1,4 @@
 import type { ConnectPanelChannelOptions, CreatePageScriptChannelOptions, InPageChannelProtocol, PageScriptChannel, PanelChannel } from './types'
-import { Diagnostic } from 'devframe/utils/nostics'
 import { describe, expect, it, vi } from 'vitest'
 import { InPageChannelError } from './internal'
 import { createPageScriptChannel } from './page-script'
@@ -125,15 +124,9 @@ describe('in-page channel over bring-your-own ports', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const { panel, dispose } = createLinkedPair()
     try {
-      let rejection: unknown
-      try {
+      expect(() => {
         panel.on('missing' as any, () => {})
-      }
-      catch (error) {
-        rejection = error
-      }
-      expect(rejection).toBeInstanceOf(Diagnostic)
-      expect(rejection).toMatchObject({ name: 'DF0077' })
+      }).toThrowError(expect.objectContaining({ name: 'DF0077' }))
       expect(warn).toHaveBeenCalledOnce()
       expect(warn).toHaveBeenCalledWith(expect.stringContaining('[DF0077]'))
     }

--- a/packages/devframe/src/in-page-channel/in-page-channel.test.ts
+++ b/packages/devframe/src/in-page-channel/in-page-channel.test.ts
@@ -120,20 +120,19 @@ describe('in-page channel over bring-your-own ports', () => {
     }
   })
 
-  it('reports and rejects listeners for unknown functions', () => {
+  it('reports and rejects listeners for unknown functions', ({ onTestFinished }) => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const { panel, dispose } = createLinkedPair()
-    try {
-      expect(() => {
-        panel.on('missing' as any, () => {})
-      }).toThrowError(expect.objectContaining({ name: 'DF0077' }))
-      expect(warn).toHaveBeenCalledOnce()
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining('[DF0077]'))
-    }
-    finally {
+    onTestFinished(() => {
       dispose()
       warn.mockRestore()
-    }
+    })
+
+    expect(() => {
+      panel.on('missing' as any, () => {})
+    }).toThrowError(expect.objectContaining({ name: 'DF0077' }))
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('[DF0077]'))
   })
 
   it('enforces jsonSerializable payloads with a coded error', async () => {

--- a/packages/devframe/src/in-page-channel/in-page-channel.test.ts
+++ b/packages/devframe/src/in-page-channel/in-page-channel.test.ts
@@ -1,4 +1,5 @@
 import type { ConnectPanelChannelOptions, CreatePageScriptChannelOptions, InPageChannelProtocol, PageScriptChannel, PanelChannel } from './types'
+import { Diagnostic } from 'devframe/utils/nostics'
 import { describe, expect, it, vi } from 'vitest'
 import { InPageChannelError } from './internal'
 import { createPageScriptChannel } from './page-script'
@@ -117,6 +118,28 @@ describe('in-page channel over bring-your-own ports', () => {
     }
     finally {
       dispose()
+    }
+  })
+
+  it('reports and rejects listeners for unknown functions', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { panel, dispose } = createLinkedPair()
+    try {
+      let rejection: unknown
+      try {
+        panel.on('missing' as any, () => {})
+      }
+      catch (error) {
+        rejection = error
+      }
+      expect(rejection).toBeInstanceOf(Diagnostic)
+      expect(rejection).toMatchObject({ name: 'DF0077' })
+      expect(warn).toHaveBeenCalledOnce()
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('[DF0077]'))
+    }
+    finally {
+      dispose()
+      warn.mockRestore()
     }
   })
 

--- a/packages/devframe/src/in-page-channel/index.ts
+++ b/packages/devframe/src/in-page-channel/index.ts
@@ -33,7 +33,7 @@ export type {
 export function defineChannelFunction<
   NAME extends string,
   TYPE extends InPageFunctionType,
-  ARGS extends any[] = [],
+  ARGS extends any[],
   RETURN = void,
   const AS extends RpcArgsSchema | undefined = undefined,
   const RS extends RpcReturnSchema | undefined = undefined,

--- a/packages/devframe/src/in-page-channel/index.ts
+++ b/packages/devframe/src/in-page-channel/index.ts
@@ -33,7 +33,7 @@ export type {
 export function defineChannelFunction<
   NAME extends string,
   TYPE extends InPageFunctionType,
-  ARGS extends any[],
+  ARGS extends any[] = [],
   RETURN = void,
   const AS extends RpcArgsSchema | undefined = undefined,
   const RS extends RpcReturnSchema | undefined = undefined,

--- a/packages/devframe/src/in-page-channel/internal.ts
+++ b/packages/devframe/src/in-page-channel/internal.ts
@@ -199,7 +199,7 @@ export function createLocalFunctionRegistry(codec: InPageChannelSerialization): 
           assertJsonSerializable(args, 'its arguments', definition.name)
         if (definition?.args?.length)
           await validateArgs(definition.name, definition.args, args)
-        const result = await definition?.handler(...args)
+        const result = await definition?.handler?.(...args)
         for (const listener of [...(listeners.get(name) ?? [])])
           listener(...args)
         if (definition?.jsonSerializable)

--- a/packages/devframe/src/in-page-channel/internal.ts
+++ b/packages/devframe/src/in-page-channel/internal.ts
@@ -166,24 +166,47 @@ export function deserializeResult(codec: InPageChannelSerialization, result: unk
  */
 export function createLocalFunctionRegistry(codec: InPageChannelSerialization): {
   register: (definition: InPageFunctionDefinitionAny) => void
+  on: (name: string, listener: (...args: unknown[]) => void) => () => void
   resolve: (name: string) => ((...args: unknown[]) => unknown) | undefined
 } {
-  const wrapped = new Map<string, (...args: unknown[]) => unknown>()
+  const definitions = new Map<string, InPageFunctionDefinitionAny>()
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>()
   return {
     register(definition) {
-      wrapped.set(definition.name, async (...rawArgs: unknown[]) => {
+      definitions.set(definition.name, definition)
+    },
+    on(name, listener) {
+      let registered = listeners.get(name)
+      if (!registered) {
+        registered = new Set()
+        listeners.set(name, registered)
+      }
+      registered.add(listener)
+      return () => {
+        registered.delete(listener)
+        if (registered.size === 0)
+          listeners.delete(name)
+      }
+    },
+    resolve(name) {
+      const definition = definitions.get(name)
+      const registered = listeners.get(name)
+      if (!definition && !registered?.size)
+        return undefined
+      return async (...rawArgs: unknown[]) => {
         const args = codec.deserialize ? rawArgs.map(codec.deserialize) : rawArgs
-        if (definition.jsonSerializable)
+        if (definition?.jsonSerializable)
           assertJsonSerializable(args, 'its arguments', definition.name)
-        if (definition.args?.length)
+        if (definition?.args?.length)
           await validateArgs(definition.name, definition.args, args)
-        const result = await definition.handler(...args)
-        if (definition.jsonSerializable)
+        const result = await definition?.handler(...args)
+        for (const listener of [...(listeners.get(name) ?? [])])
+          listener(...args)
+        if (definition?.jsonSerializable)
           assertJsonSerializable(result, 'its return value', definition.name)
         return codec.serialize && result !== undefined ? codec.serialize(result) : result
-      })
+      }
     },
-    resolve: name => wrapped.get(name),
   }
 }
 

--- a/packages/devframe/src/in-page-channel/internal.ts
+++ b/packages/devframe/src/in-page-channel/internal.ts
@@ -4,13 +4,13 @@ import type { RpcArgsSchema } from '../rpc/types'
 import type { InPageChannelControlFrame } from './protocol'
 import type { InPageFunctionDefinitionAny } from './types'
 import { createBirpc } from 'birpc'
+import { diagnostics } from './diagnostics'
 import { isControlFrame } from './protocol'
 
 /**
- * Shared internals of the two endpoints: the coded error surface (browser
- * code, so plain coded `Error`s, since `nostics` diagnostics are node-side only),
- * the local function table with its receive pipeline, and the birpc wiring
- * of one `MessagePort`.
+ * Shared internals of the two endpoints: the coded error surface, the local
+ * function table with its receive pipeline, and the birpc wiring of one
+ * `MessagePort`.
  */
 
 export const DEFAULT_CALL_TIMEOUT_MS = 15_000
@@ -176,6 +176,8 @@ export function createLocalFunctionRegistry(codec: InPageChannelSerialization): 
       definitions.set(definition.name, definition)
     },
     on(name, listener) {
+      if (!definitions.has(name))
+        throw diagnostics.DF0077({ name })
       let registered = listeners.get(name)
       if (!registered) {
         registered = new Set()

--- a/packages/devframe/src/in-page-channel/page-script.ts
+++ b/packages/devframe/src/in-page-channel/page-script.ts
@@ -63,8 +63,10 @@ export function createPageScriptChannel<P extends InPageChannelProtocol>(
   let heartbeatTimer: ReturnType<typeof setInterval> | undefined
 
   const registry = createLocalFunctionRegistry(codec)
-  for (const [fnName, definition] of Object.entries(options.functions ?? {}))
-    registry.register({ ...definition, name: fnName })
+  for (const [fnName, definition] of Object.entries(options.functions ?? {})) {
+    if (definition)
+      registry.register({ ...definition, name: fnName })
+  }
 
   const stateHost = createPageScriptStateHost<P>(function* () {
     for (const peer of peers.values()) {
@@ -174,6 +176,18 @@ export function createPageScriptChannel<P extends InPageChannelProtocol>(
 
   win?.addEventListener('message', onWindowMessage)
 
+  const emit: PageScriptChannel<P>['emit'] = (fnName, ...args) => {
+    const wireArgs = serializeArgs(codec, args)
+    for (const peer of peers.values()) {
+      void peer.attached.rpc.$callRaw({
+        method: fnName,
+        args: wireArgs,
+        event: true,
+        optional: true,
+      }).catch(() => {})
+    }
+  }
+
   return {
     name,
     instanceId,
@@ -181,17 +195,9 @@ export function createPageScriptChannel<P extends InPageChannelProtocol>(
       return [...peers.values()].map(peer => peer.peer)
     },
     events: { on: events.on, once: events.once },
-    callEvent: (fnName, ...args) => {
-      const wireArgs = serializeArgs(codec, args)
-      for (const peer of peers.values()) {
-        void peer.attached.rpc.$callRaw({
-          method: fnName,
-          args: wireArgs,
-          event: true,
-          optional: true,
-        }).catch(() => {})
-      }
-    },
+    emit,
+    callEvent: emit,
+    on: (fnName, listener) => registry.on(fnName, listener as (...args: unknown[]) => void),
     sharedState: stateHost,
     addPanelPort: port => addPeer(port, `transport:${nanoid(8)}`),
     close: () => {

--- a/packages/devframe/src/in-page-channel/page-script.ts
+++ b/packages/devframe/src/in-page-channel/page-script.ts
@@ -63,10 +63,8 @@ export function createPageScriptChannel<P extends InPageChannelProtocol>(
   let heartbeatTimer: ReturnType<typeof setInterval> | undefined
 
   const registry = createLocalFunctionRegistry(codec)
-  for (const [fnName, definition] of Object.entries(options.functions ?? {})) {
-    if (definition)
-      registry.register({ ...definition, name: fnName })
-  }
+  for (const [fnName, definition] of Object.entries(options.functions))
+    registry.register({ ...definition, name: fnName })
 
   const stateHost = createPageScriptStateHost<P>(function* () {
     for (const peer of peers.values()) {

--- a/packages/devframe/src/in-page-channel/panel.ts
+++ b/packages/devframe/src/in-page-channel/panel.ts
@@ -62,10 +62,8 @@ export function connectPanelChannel<P extends InPageChannelProtocol>(
 
   const events = createEventEmitter<PanelChannelEvents>()
   const registry = createLocalFunctionRegistry(codec)
-  for (const [fnName, definition] of Object.entries(options.functions ?? {})) {
-    if (definition)
-      registry.register({ ...definition, name: fnName })
-  }
+  for (const [fnName, definition] of Object.entries(options.functions))
+    registry.register({ ...definition, name: fnName })
 
   let status: InPageChannelStatus = 'connecting'
   let attached: AttachedChannelPort | undefined

--- a/packages/devframe/src/in-page-channel/panel.ts
+++ b/packages/devframe/src/in-page-channel/panel.ts
@@ -62,8 +62,10 @@ export function connectPanelChannel<P extends InPageChannelProtocol>(
 
   const events = createEventEmitter<PanelChannelEvents>()
   const registry = createLocalFunctionRegistry(codec)
-  for (const [fnName, definition] of Object.entries(options.functions ?? {}))
-    registry.register({ ...definition, name: fnName })
+  for (const [fnName, definition] of Object.entries(options.functions ?? {})) {
+    if (definition)
+      registry.register({ ...definition, name: fnName })
+  }
 
   let status: InPageChannelStatus = 'connecting'
   let attached: AttachedChannelPort | undefined
@@ -284,7 +286,9 @@ export function connectPanelChannel<P extends InPageChannelProtocol>(
       })
     },
     call: (fnName, ...args) => enqueueCall(fnName, serializeArgs(codec, args)) as Promise<any>,
+    emit: (fnName, ...args) => sendEvent(fnName, serializeArgs(codec, args)),
     callEvent: (fnName, ...args) => sendEvent(fnName, serializeArgs(codec, args)),
+    on: (fnName, listener) => registry.on(fnName, listener as (...args: unknown[]) => void),
     sharedState: stateHost,
     close: () => {
       if (status === 'closed')

--- a/packages/devframe/src/in-page-channel/types.test-d.ts
+++ b/packages/devframe/src/in-page-channel/types.test-d.ts
@@ -57,13 +57,11 @@ describe('In-page script channel', () => {
       })
     })
 
-    it('requires every in-page script function', () => {
-      // @ts-expect-error `functions` is required.
+    it('accepts runtime-only and partial function implementations', () => {
       createPageScriptChannel<TestProtocol>({ name: 'devframes:test' })
 
       createPageScriptChannel<TestProtocol>({
         name: 'devframes:test',
-        // @ts-expect-error `sum` and `save` are required.
         functions: {
           echo: { handler: value => value },
         },
@@ -100,16 +98,16 @@ describe('In-page script channel', () => {
 
   describe('Function calling', () => {
     it('types fire-and-forget calls to panel functions', () => {
-      expectTypeOf(channel.callEvent('notify', 'ready')).toEqualTypeOf<void>()
+      expectTypeOf(channel.emit('notify', 'ready')).toEqualTypeOf<void>()
 
       // @ts-expect-error In-page script functions cannot be called on panels.
-      channel.callEvent('echo', 'ready')
+      channel.emit('echo', 'ready')
       // @ts-expect-error `notify` requires a string.
-      channel.callEvent('notify', 42)
+      channel.emit('notify', 42)
       // @ts-expect-error `notify` requires one argument.
-      channel.callEvent('notify')
+      channel.emit('notify')
       // @ts-expect-error `notify` accepts one argument.
-      channel.callEvent('notify', 'ready', 'extra')
+      channel.emit('notify', 'ready', 'extra')
     })
 
     it('types calls to connected panels', () => {
@@ -133,11 +131,23 @@ describe('In-page script channel', () => {
       })
 
       // @ts-expect-error The protocol has no panel functions.
-      pageScriptOnlyChannel.callEvent('notify', 'ready')
+      pageScriptOnlyChannel.emit('notify', 'ready')
     })
   })
 
   describe('Event checking', () => {
+    it('types runtime subscriptions to page-script functions', () => {
+      const unsubscribe = channel.on('echo', (value) => {
+        expectTypeOf(value).toEqualTypeOf<string>()
+      })
+
+      expectTypeOf(unsubscribe).toEqualTypeOf<() => void>()
+      // @ts-expect-error Panel functions cannot be handled by the page script.
+      channel.on('notify', () => {})
+      // @ts-expect-error `echo` listeners receive a string.
+      channel.on('echo', (value: number) => void value)
+    })
+
     it('types panel connection events', () => {
       const unsubscribeConnected = channel.events.on('panel:connected', (panel) => {
         expectTypeOf(panel.id).toEqualTypeOf<string>()
@@ -185,13 +195,11 @@ describe('Panel channel', () => {
       inferredChannel.close()
     })
 
-    it('requires every panel function', () => {
-      // @ts-expect-error `functions` is required.
+    it('accepts runtime-only and partial function implementations', () => {
       connectPanelChannel<TestProtocol>({ name: 'devframes:test' })
 
       connectPanelChannel<TestProtocol>({
         name: 'devframes:test',
-        // @ts-expect-error `notify` is required.
         functions: {},
       })
     })
@@ -252,16 +260,16 @@ describe('Panel channel', () => {
     })
 
     it('types fire-and-forget calls to in-page script functions', () => {
-      expectTypeOf(channel.callEvent('echo', 'hello')).toEqualTypeOf<void>()
-      expectTypeOf(channel.callEvent('sum', 1, 2)).toEqualTypeOf<void>()
-      expectTypeOf(channel.callEvent('save', 'draft')).toEqualTypeOf<void>()
+      expectTypeOf(channel.emit('echo', 'hello')).toEqualTypeOf<void>()
+      expectTypeOf(channel.emit('sum', 1, 2)).toEqualTypeOf<void>()
+      expectTypeOf(channel.emit('save', 'draft')).toEqualTypeOf<void>()
 
       // @ts-expect-error Panel functions cannot be emitted to the in-page script.
-      channel.callEvent('notify', 'hello')
+      channel.emit('notify', 'hello')
       // @ts-expect-error `echo` requires a string.
-      channel.callEvent('echo', false)
+      channel.emit('echo', false)
       // @ts-expect-error `sum` requires two arguments.
-      channel.callEvent('sum', 1)
+      channel.emit('sum', 1)
     })
 
     it('types channel state', () => {
@@ -273,6 +281,18 @@ describe('Panel channel', () => {
   })
 
   describe('Event checking', () => {
+    it('types runtime subscriptions to panel functions', () => {
+      const unsubscribe = channel.on('notify', (message) => {
+        expectTypeOf(message).toEqualTypeOf<string>()
+      })
+
+      expectTypeOf(unsubscribe).toEqualTypeOf<() => void>()
+      // @ts-expect-error Page-script functions cannot be handled by the panel.
+      channel.on('echo', () => {})
+      // @ts-expect-error `notify` listeners receive a string.
+      channel.on('notify', (message: number) => void message)
+    })
+
     it('types status events', () => {
       const unsubscribe = channel.events.on('status:updated', (status) => {
         expectTypeOf(status).toEqualTypeOf<'connecting' | 'connected' | 'closed'>()

--- a/packages/devframe/src/in-page-channel/types.test-d.ts
+++ b/packages/devframe/src/in-page-channel/types.test-d.ts
@@ -22,8 +22,11 @@ interface PageScriptOnlyProtocol {
 }
 
 describe('Channel function definitions', () => {
-  it('allows events without handlers', () => {
+  it('distinguishes event, query, and action definitions', () => {
     defineChannelFunction({ name: 'notify', type: 'event' })
+    defineChannelFunction({ name: 'load', handler: () => 'value' })
+    defineChannelFunction({ name: 'load', type: 'query', handler: () => 'value' })
+    defineChannelFunction({ name: 'save', type: 'action', handler: () => {} })
   })
 
   it('requires handlers for request/response functions', () => {
@@ -88,8 +91,8 @@ describe('In-page script channel', () => {
       createPageScriptChannel<TestProtocol>({
         name: 'devframes:test',
         functions: {
-          echo: { handler: value => value },
-          sum: { handler: (a, b) => a + b },
+          echo: { type: 'query', handler: value => value },
+          sum: { type: 'action', handler: (a, b) => a + b },
           save: { type: 'event' },
         },
       })
@@ -99,7 +102,8 @@ describe('In-page script channel', () => {
         functions: {
           // @ts-expect-error Request/response functions require a handler.
           echo: { type: 'query' },
-          sum: { handler: (a, b) => a + b },
+          // @ts-expect-error Request/response functions require a handler.
+          sum: { type: 'action' },
           save: { type: 'event' },
         },
       })

--- a/packages/devframe/src/in-page-channel/types.test-d.ts
+++ b/packages/devframe/src/in-page-channel/types.test-d.ts
@@ -1,4 +1,5 @@
 import { describe, expectTypeOf, it } from 'vitest'
+import { defineChannelFunction } from './index'
 import { createPageScriptChannel } from './page-script'
 import { connectPanelChannel } from './panel'
 
@@ -19,6 +20,19 @@ interface PageScriptOnlyProtocol {
   }
   panel: Record<string, never>
 }
+
+describe('Channel function definitions', () => {
+  it('allows events without handlers', () => {
+    defineChannelFunction({ name: 'notify', type: 'event' })
+  })
+
+  it('requires handlers for request/response functions', () => {
+    // @ts-expect-error Query functions require a handler.
+    defineChannelFunction({ name: 'load', type: 'query' })
+    // @ts-expect-error Action functions require a handler.
+    defineChannelFunction({ name: 'save', type: 'action' })
+  })
+})
 
 describe('In-page script channel', () => {
   const channel = createPageScriptChannel<TestProtocol>({
@@ -57,13 +71,36 @@ describe('In-page script channel', () => {
       })
     })
 
-    it('accepts runtime-only and partial function implementations', () => {
+    it('requires every page-script function declaration', () => {
+      // @ts-expect-error `functions` is required.
       createPageScriptChannel<TestProtocol>({ name: 'devframes:test' })
 
       createPageScriptChannel<TestProtocol>({
         name: 'devframes:test',
+        // @ts-expect-error `sum` and `save` must be declared.
         functions: {
           echo: { handler: value => value },
+        },
+      })
+    })
+
+    it('allows event declarations to omit their handler', () => {
+      createPageScriptChannel<TestProtocol>({
+        name: 'devframes:test',
+        functions: {
+          echo: { handler: value => value },
+          sum: { handler: (a, b) => a + b },
+          save: { type: 'event' },
+        },
+      })
+
+      createPageScriptChannel<TestProtocol>({
+        name: 'devframes:test',
+        functions: {
+          // @ts-expect-error Request/response functions require a handler.
+          echo: { type: 'query' },
+          sum: { handler: (a, b) => a + b },
+          save: { type: 'event' },
         },
       })
     })
@@ -195,12 +232,31 @@ describe('Panel channel', () => {
       inferredChannel.close()
     })
 
-    it('accepts runtime-only and partial function implementations', () => {
+    it('requires every panel function declaration', () => {
+      // @ts-expect-error `functions` is required.
       connectPanelChannel<TestProtocol>({ name: 'devframes:test' })
 
       connectPanelChannel<TestProtocol>({
         name: 'devframes:test',
+        // @ts-expect-error `notify` must be declared.
         functions: {},
+      })
+    })
+
+    it('allows event declarations to omit their handler', () => {
+      connectPanelChannel<TestProtocol>({
+        name: 'devframes:test',
+        functions: {
+          notify: { type: 'event' },
+        },
+      })
+
+      connectPanelChannel<TestProtocol>({
+        name: 'devframes:test',
+        functions: {
+          // @ts-expect-error Request/response functions require a handler.
+          notify: { type: 'action' },
+        },
       })
     })
 

--- a/packages/devframe/src/in-page-channel/types.test-d.ts
+++ b/packages/devframe/src/in-page-channel/types.test-d.ts
@@ -34,7 +34,7 @@ describe('Channel function definitions', () => {
     defineChannelFunction({ name: 'notify', type: 'event' })
     defineChannelFunction({ name: 'load', handler: () => 'value' })
     defineChannelFunction({ name: 'load', type: 'query', handler: () => 'value' })
-    defineChannelFunction({ name: 'save', type: 'action', handler: () => {} })
+    defineChannelFunction({ name: 'save', type: 'action', handler: () => { } })
   })
 
   it('requires handlers for request/response functions', () => {
@@ -51,7 +51,7 @@ describe('In-page script channel', () => {
     functions: {
       echo: { handler: value => value },
       sum: { handler: (a, b) => a + b },
-      save: { handler: () => {} },
+      save: { handler: () => { } },
     },
   })
 
@@ -82,13 +82,13 @@ describe('In-page script channel', () => {
       })
     })
 
-    it('requires every in-page-script function', () => {
+    it('requires every in-page script function', () => {
       // @ts-expect-error `functions` is required.
       createPageScriptChannel<TestProtocol>({ name: 'devframes:test' })
 
       createPageScriptChannel<TestProtocol>({
         name: 'devframes:test',
-        // @ts-expect-error `sum` and `save` are required
+        // @ts-expect-error `sum` and `save` are required.
         functions: {
           echo: { handler: value => value },
         },
@@ -123,7 +123,7 @@ describe('In-page script channel', () => {
         functions: {
           echo: { handler: value => value },
           sum: { handler: (a, b) => a + b },
-          save: { handler: () => {} },
+          save: { handler: () => { } },
           // @ts-expect-error `notify` is implemented by panels.
           notify: { handler: (message: string) => void message },
         },
@@ -139,7 +139,7 @@ describe('In-page script channel', () => {
             handler: (value: number) => value,
           },
           sum: { handler: (a, b) => a + b },
-          save: { handler: () => {} },
+          save: { handler: () => { } },
         },
       })
     })
@@ -206,9 +206,9 @@ describe('In-page script channel', () => {
 
       expectTypeOf(unsubscribe).toEqualTypeOf<() => void>()
       // @ts-expect-error Panel functions cannot be handled by the page script.
-      channel.on('notify', () => {})
+      channel.on('notify', () => { })
       // @ts-expect-error Query functions cannot be handled as events.
-      channel.on('echo', () => {})
+      channel.on('echo', () => { })
       // @ts-expect-error `save` listeners receive a string.
       channel.on('save', (value: number) => void value)
     })
@@ -229,7 +229,7 @@ describe('In-page script channel', () => {
 
     it('rejects panel channel events', () => {
       // @ts-expect-error Unknown in-page script channel lifecycle event.
-      channel.events.on('status:updated', () => {})
+      channel.events.on('status:updated', () => { })
     })
   })
 })
@@ -238,7 +238,7 @@ describe('Panel channel', () => {
   const channel = connectPanelChannel<TestProtocol>({
     name: 'devframes:test',
     functions: {
-      notify: { handler: () => {} },
+      notify: { handler: () => { } },
     },
   })
 
@@ -292,7 +292,7 @@ describe('Panel channel', () => {
       connectPanelChannel<TestProtocol>({
         name: 'devframes:test',
         functions: {
-          notify: { handler: () => {} },
+          notify: { handler: () => { } },
           // @ts-expect-error `echo` is implemented by the in-page script.
           echo: { handler: (value: string) => value },
         },
@@ -321,7 +321,7 @@ describe('Panel channel', () => {
         name: 'devframes:page-script-only',
         functions: {
           // @ts-expect-error The protocol has no panel functions.
-          notify: { handler: () => {} },
+          notify: { handler: () => { } },
         },
       })
     })
@@ -375,7 +375,7 @@ describe('Panel channel', () => {
 
       expectTypeOf(unsubscribe).toEqualTypeOf<() => void>()
       // @ts-expect-error Page-script functions cannot be handled by the panel.
-      channel.on('echo', () => {})
+      channel.on('echo', () => { })
       // @ts-expect-error `notify` listeners receive a string.
       channel.on('notify', (message: number) => void message)
     })
@@ -389,9 +389,9 @@ describe('Panel channel', () => {
         },
       })
 
-      mixedChannel.on('notify', () => {})
+      mixedChannel.on('notify', () => { })
       // @ts-expect-error Query functions cannot be handled as events.
-      mixedChannel.on('confirm', () => {})
+      mixedChannel.on('confirm', () => { })
     })
 
     it('types status events', () => {
@@ -404,7 +404,7 @@ describe('Panel channel', () => {
 
     it('rejects in-page script channel events and incompatible listeners', () => {
       // @ts-expect-error Unknown panel channel lifecycle event.
-      channel.events.on('panel:connected', () => {})
+      channel.events.on('panel:connected', () => { })
       // @ts-expect-error `status:updated` listeners receive the status.
       channel.events.on('status:updated', (status: number) => void status)
     })

--- a/packages/devframe/src/in-page-channel/types.test-d.ts
+++ b/packages/devframe/src/in-page-channel/types.test-d.ts
@@ -82,13 +82,13 @@ describe('In-page script channel', () => {
       })
     })
 
-    it('requires every page-script function declaration', () => {
+    it('requires every in-page-script function', () => {
       // @ts-expect-error `functions` is required.
       createPageScriptChannel<TestProtocol>({ name: 'devframes:test' })
 
       createPageScriptChannel<TestProtocol>({
         name: 'devframes:test',
-        // @ts-expect-error `sum` and `save` must be declared.
+        // @ts-expect-error `sum` and `save` are required
         functions: {
           echo: { handler: value => value },
         },

--- a/packages/devframe/src/in-page-channel/types.test-d.ts
+++ b/packages/devframe/src/in-page-channel/types.test-d.ts
@@ -148,6 +148,7 @@ describe('In-page script channel', () => {
   describe('Function calling', () => {
     it('types fire-and-forget calls to panel functions', () => {
       expectTypeOf(channel.emit('notify', 'ready')).toEqualTypeOf<void>()
+      expectTypeOf(channel.callEvent('notify', 'ready')).toEqualTypeOf<void>()
 
       // @ts-expect-error In-page script functions cannot be called on panels.
       channel.emit('echo', 'ready')
@@ -157,6 +158,19 @@ describe('In-page script channel', () => {
       channel.emit('notify')
       // @ts-expect-error `notify` accepts one argument.
       channel.emit('notify', 'ready', 'extra')
+    })
+
+    it('rejects fire-and-forget calls to panel queries', () => {
+      const mixedChannel = createPageScriptChannel<MixedPanelProtocol>({
+        name: 'devframes:mixed-panel',
+        functions: {},
+      })
+
+      mixedChannel.emit('notify', 'ready')
+      // @ts-expect-error Queries cannot be emitted as events.
+      mixedChannel.emit('confirm', 'continue?')
+      // @ts-expect-error The deprecated alias has the same event-only contract.
+      mixedChannel.callEvent('confirm', 'continue?')
     })
 
     it('types calls to connected panels', () => {
@@ -330,16 +344,19 @@ describe('Panel channel', () => {
     })
 
     it('types fire-and-forget calls to in-page script functions', () => {
-      expectTypeOf(channel.emit('echo', 'hello')).toEqualTypeOf<void>()
-      expectTypeOf(channel.emit('sum', 1, 2)).toEqualTypeOf<void>()
       expectTypeOf(channel.emit('save', 'draft')).toEqualTypeOf<void>()
+      expectTypeOf(channel.callEvent('save', 'draft')).toEqualTypeOf<void>()
 
       // @ts-expect-error Panel functions cannot be emitted to the in-page script.
       channel.emit('notify', 'hello')
-      // @ts-expect-error `echo` requires a string.
-      channel.emit('echo', false)
-      // @ts-expect-error `sum` requires two arguments.
-      channel.emit('sum', 1)
+      // @ts-expect-error Queries cannot be emitted as events.
+      channel.emit('echo', 'hello')
+      // @ts-expect-error Queries cannot be emitted as events.
+      channel.emit('sum', 1, 2)
+      // @ts-expect-error `save` requires a string.
+      channel.emit('save', false)
+      // @ts-expect-error The deprecated alias has the same event-only contract.
+      channel.callEvent('echo', 'hello')
     })
 
     it('types channel state', () => {

--- a/packages/devframe/src/in-page-channel/types.test-d.ts
+++ b/packages/devframe/src/in-page-channel/types.test-d.ts
@@ -21,6 +21,14 @@ interface PageScriptOnlyProtocol {
   panel: Record<string, never>
 }
 
+interface MixedPanelProtocol {
+  pageScript: Record<string, never>
+  panel: {
+    confirm: (message: string) => boolean
+    notify: (message: string) => void
+  }
+}
+
 describe('Channel function definitions', () => {
   it('distinguishes event, query, and action definitions', () => {
     defineChannelFunction({ name: 'notify', type: 'event' })
@@ -177,16 +185,18 @@ describe('In-page script channel', () => {
   })
 
   describe('Event checking', () => {
-    it('types runtime subscriptions to page-script functions', () => {
-      const unsubscribe = channel.on('echo', (value) => {
+    it('types runtime subscriptions to page-script events', () => {
+      const unsubscribe = channel.on('save', (value) => {
         expectTypeOf(value).toEqualTypeOf<string>()
       })
 
       expectTypeOf(unsubscribe).toEqualTypeOf<() => void>()
       // @ts-expect-error Panel functions cannot be handled by the page script.
       channel.on('notify', () => {})
-      // @ts-expect-error `echo` listeners receive a string.
-      channel.on('echo', (value: number) => void value)
+      // @ts-expect-error Query functions cannot be handled as events.
+      channel.on('echo', () => {})
+      // @ts-expect-error `save` listeners receive a string.
+      channel.on('save', (value: number) => void value)
     })
 
     it('types panel connection events', () => {
@@ -351,6 +361,20 @@ describe('Panel channel', () => {
       channel.on('echo', () => {})
       // @ts-expect-error `notify` listeners receive a string.
       channel.on('notify', (message: number) => void message)
+    })
+
+    it('rejects runtime subscriptions to panel queries', () => {
+      const mixedChannel = connectPanelChannel<MixedPanelProtocol>({
+        name: 'devframes:mixed-panel',
+        functions: {
+          confirm: { handler: () => true },
+          notify: { type: 'event' },
+        },
+      })
+
+      mixedChannel.on('notify', () => {})
+      // @ts-expect-error Query functions cannot be handled as events.
+      mixedChannel.on('confirm', () => {})
     })
 
     it('types status events', () => {

--- a/packages/devframe/src/in-page-channel/types.ts
+++ b/packages/devframe/src/in-page-channel/types.ts
@@ -54,7 +54,8 @@ export type InPageFunctionType = 'action' | 'event' | 'query'
  * `dump`/`snapshot`/`cacheable`/`agent`. When `jsonSerializable` is `true`,
  * payloads are strictly validated at the receiving endpoint and misshapen
  * values reject the call with a descriptive `InPageChannelError` instead of
- * a cryptic `DataCloneError` in the port.
+ * a cryptic `DataCloneError` in the port. Event definitions may omit their
+ * handler when runtime listeners subscribe through `channel.on()`.
  */
 export type InPageFunctionDefinition<
   NAME extends string,
@@ -65,15 +66,16 @@ export type InPageFunctionDefinition<
   RS extends RpcReturnSchema | undefined = undefined,
 >
   = [AS, RS] extends [undefined, undefined]
-    ? {
+    ? ({
         name: NAME
         type?: TYPE
         args?: AS
         returns?: RS
         jsonSerializable?: boolean
-        handler: (...args: ARGS) => RETURN
-      }
-    : {
+      } & (TYPE extends 'event'
+        ? { handler?: (...args: ARGS) => RETURN }
+        : { handler: (...args: ARGS) => RETURN }))
+    : ({
         name: NAME
         type?: TYPE
         /** Standard Schema array validating (and typing) the arguments. */
@@ -81,8 +83,9 @@ export type InPageFunctionDefinition<
         /** Standard Schema typing the resolved return value. */
         returns: RS
         jsonSerializable?: boolean
-        handler: (...args: InferArgsType<AS>) => Thenable<InferReturnType<RS>>
-      }
+      } & (TYPE extends 'event'
+        ? { handler?: (...args: InferArgsType<AS>) => Thenable<InferReturnType<RS>> }
+        : { handler: (...args: InferArgsType<AS>) => Thenable<InferReturnType<RS>> }))
 
 /**
  * Loosely-typed definition used by the internal function registry.
@@ -96,33 +99,41 @@ export type InPageFunctionDefinitionAny = InPageFunctionDefinition<string, any, 
  *
  * @internal
  */
-interface InPageFunctionOption<F> {
-  type?: InPageFunctionType
+interface InPageFunctionOptionBase {
   /** Optional Standard Schema array validating the arguments. */
   args?: RpcArgsSchema
   /** Optional Standard Schema validating the resolved return value. */
   returns?: RpcReturnSchema
   jsonSerializable?: boolean
-  handler: ProtocolHandler<F>
 }
+
+type InPageFunctionOption<F>
+  = | (InPageFunctionOptionBase & {
+    type: 'event'
+    handler?: ProtocolHandler<F>
+  })
+  | (InPageFunctionOptionBase & {
+    type?: Exclude<InPageFunctionType, 'event'>
+    handler: ProtocolHandler<F>
+  })
 
 /**
  * Functions implemented by {@link createPageScriptChannel}.
  *
  * @internal
  */
-type CreatePageScriptChannelOptionsFunctions<P extends InPageChannelProtocol> = Partial<{
+type CreatePageScriptChannelOptionsFunctions<P extends InPageChannelProtocol> = {
   [NAME in keyof PageScriptFunctions<P> & string]: InPageFunctionOption<PageScriptFunctions<P>[NAME]>
-}>
+}
 
 /**
  * Functions implemented by {@link connectPanelChannel}.
  *
  * @internal
  */
-type ConnectPanelChannelOptionsFunctions<P extends InPageChannelProtocol> = Partial<{
+type ConnectPanelChannelOptionsFunctions<P extends InPageChannelProtocol> = {
   [NAME in keyof PanelFunctions<P> & string]: InPageFunctionOption<PanelFunctions<P>[NAME]>
-}>
+}
 
 /**
  * Connection lifecycle of a panel endpoint: `connecting` (handshake retry
@@ -173,8 +184,8 @@ interface InPageChannelCommonOptions {
 
 /** Options for {@link createPageScriptChannel}. */
 export interface CreatePageScriptChannelOptions<Protocol extends InPageChannelProtocol = InPageChannelProtocol> extends InPageChannelCommonOptions {
-  /** Initial page-script handlers. Event listeners may also use `channel.on()`. */
-  functions?: CreatePageScriptChannelOptionsFunctions<Protocol>
+  /** Every page-script function declaration; event handlers may use `channel.on()`. */
+  functions: CreatePageScriptChannelOptionsFunctions<Protocol>
   /**
    * Window whose `message` events carry panel hellos. Defaults to the
    * global `window`; pass `false` to skip the handshake listener entirely
@@ -185,8 +196,8 @@ export interface CreatePageScriptChannelOptions<Protocol extends InPageChannelPr
 
 /** Options for {@link connectPanelChannel}. */
 export interface ConnectPanelChannelOptions<Protocol extends InPageChannelProtocol = InPageChannelProtocol> extends InPageChannelCommonOptions {
-  /** Initial panel handlers. Event listeners may also use `channel.on()`. */
-  functions?: ConnectPanelChannelOptionsFunctions<Protocol>
+  /** Every panel function declaration; event handlers may use `channel.on()`. */
+  functions: ConnectPanelChannelOptionsFunctions<Protocol>
   /**
    * The panel's own window (listens for the handshake grant). Defaults to
    * the global `window`; pass `false` with `transport` to skip the handshake.

--- a/packages/devframe/src/in-page-channel/types.ts
+++ b/packages/devframe/src/in-page-channel/types.ts
@@ -10,9 +10,9 @@ import type { InferArgsType, InferReturnType } from '../rpc/utils'
  * channel-name constant declared next to it.
  */
 export interface InPageChannelProtocol {
-  /** Functions implemented by the page script, callable by panels. */
+  /** Functions and events received by the page script. */
   pageScript?: Record<string, (...args: any[]) => any>
-  /** Functions implemented by panels, callable by the page script. */
+  /** Functions and events received by panels. */
   panel?: Record<string, (...args: any[]) => any>
   /**
    * Shared-state slots. The page script is the authority: it owns the
@@ -111,18 +111,18 @@ interface InPageFunctionOption<F> {
  *
  * @internal
  */
-type CreatePageScriptChannelOptionsFunctions<P extends InPageChannelProtocol> = {
+type CreatePageScriptChannelOptionsFunctions<P extends InPageChannelProtocol> = Partial<{
   [NAME in keyof PageScriptFunctions<P> & string]: InPageFunctionOption<PageScriptFunctions<P>[NAME]>
-}
+}>
 
 /**
  * Functions implemented by {@link connectPanelChannel}.
  *
  * @internal
  */
-type ConnectPanelChannelOptionsFunctions<P extends InPageChannelProtocol> = {
+type ConnectPanelChannelOptionsFunctions<P extends InPageChannelProtocol> = Partial<{
   [NAME in keyof PanelFunctions<P> & string]: InPageFunctionOption<PanelFunctions<P>[NAME]>
-}
+}>
 
 /**
  * Connection lifecycle of a panel endpoint: `connecting` (handshake retry
@@ -173,8 +173,8 @@ interface InPageChannelCommonOptions {
 
 /** Options for {@link createPageScriptChannel}. */
 export interface CreatePageScriptChannelOptions<Protocol extends InPageChannelProtocol = InPageChannelProtocol> extends InPageChannelCommonOptions {
-  /** Implementations of the protocol's page-script functions. */
-  functions: CreatePageScriptChannelOptionsFunctions<Protocol>
+  /** Initial page-script handlers. Event listeners may also use `channel.on()`. */
+  functions?: CreatePageScriptChannelOptionsFunctions<Protocol>
   /**
    * Window whose `message` events carry panel hellos. Defaults to the
    * global `window`; pass `false` to skip the handshake listener entirely
@@ -185,8 +185,8 @@ export interface CreatePageScriptChannelOptions<Protocol extends InPageChannelPr
 
 /** Options for {@link connectPanelChannel}. */
 export interface ConnectPanelChannelOptions<Protocol extends InPageChannelProtocol = InPageChannelProtocol> extends InPageChannelCommonOptions {
-  /** Implementations of the protocol's panel functions. */
-  functions: ConnectPanelChannelOptionsFunctions<Protocol>
+  /** Initial panel handlers. Event listeners may also use `channel.on()`. */
+  functions?: ConnectPanelChannelOptionsFunctions<Protocol>
   /**
    * The panel's own window (listens for the handshake grant). Defaults to
    * the global `window`; pass `false` with `transport` to skip the handshake.
@@ -215,7 +215,7 @@ export interface ConnectPanelChannelOptions<Protocol extends InPageChannelProtoc
    */
   helloIntervalMs?: number
   /**
-   * Maximum `callEvent` payloads buffered while `connecting`, flushed on
+   * Maximum `emit` payloads buffered while `connecting`, flushed on
    * connect; when full, the oldest is dropped with a console warning.
    * @default 64
    */
@@ -270,14 +270,21 @@ export interface PageScriptChannel<P extends InPageChannelProtocol> {
   /** Currently connected panels. */
   readonly panels: readonly PanelPeer<P>[]
   readonly events: Pick<EventEmitter<PageScriptChannelEvents<P>>, 'on' | 'once'>
-  /**
-   * Fan a fire-and-forget event out to every connected panel; panels that
-   * don't implement the function ignore it.
-   */
+  /** Fan an event out to every connected panel. */
+  emit: <K extends keyof PanelFunctions<P> & string>(
+    name: K,
+    ...args: FnArgs<PanelFunctions<P>[K]>
+  ) => void
+  /** @deprecated Use `emit()` instead. */
   callEvent: <K extends keyof PanelFunctions<P> & string>(
     name: K,
     ...args: FnArgs<PanelFunctions<P>[K]>
   ) => void
+  /** Subscribe to an event emitted by a panel. Returns an unsubscribe function. */
+  on: <K extends keyof PageScriptFunctions<P> & string>(
+    name: K,
+    listener: (...args: FnArgs<PageScriptFunctions<P>[K]>) => void,
+  ) => () => void
   /** Page-script-authoritative shared states, replayed to joining panels. */
   readonly sharedState: InPageSharedStateHost<P>
   /** Adopt a pre-established port as a panel peer (bring-your-own transport). */
@@ -318,13 +325,23 @@ export interface PanelChannel<P extends InPageChannelProtocol> {
     ...args: FnArgs<PageScriptFunctions<P>[K]>
   ) => Promise<FnReturn<PageScriptFunctions<P>[K]>>
   /**
-   * Fire-and-forget to the page script. While `connecting` the event is
-   * buffered (up to `eventBufferLimit`) and flushed on connect.
+   * Emit an event to the page script. While `connecting` the event is buffered
+   * (up to `eventBufferLimit`) and flushed on connect.
    */
+  emit: <K extends keyof PageScriptFunctions<P> & string>(
+    name: K,
+    ...args: FnArgs<PageScriptFunctions<P>[K]>
+  ) => void
+  /** @deprecated Use `emit()` instead. */
   callEvent: <K extends keyof PageScriptFunctions<P> & string>(
     name: K,
     ...args: FnArgs<PageScriptFunctions<P>[K]>
   ) => void
+  /** Subscribe to an event emitted by the page script. Returns an unsubscribe function. */
+  on: <K extends keyof PanelFunctions<P> & string>(
+    name: K,
+    listener: (...args: FnArgs<PanelFunctions<P>[K]>) => void,
+  ) => () => void
   /** Shared states mirrored from the page-script authority. */
   readonly sharedState: InPageSharedStateHost<P>
   /** Tear the endpoint down permanently. */

--- a/packages/devframe/src/in-page-channel/types.ts
+++ b/packages/devframe/src/in-page-channel/types.ts
@@ -47,6 +47,60 @@ type ProtocolHandler<F> = F extends (...args: any[]) => any
  */
 export type InPageFunctionType = 'action' | 'event' | 'query'
 
+interface InPageFunctionDefinitionBase<NAME extends string> {
+  name: NAME
+  jsonSerializable?: boolean
+}
+
+interface InPageEventFunctionDefinition<NAME extends string, HANDLER> extends InPageFunctionDefinitionBase<NAME> {
+  type: 'event'
+  handler?: HANDLER
+}
+
+interface InPageQueryFunctionDefinition<NAME extends string, HANDLER> extends InPageFunctionDefinitionBase<NAME> {
+  type?: 'query'
+  handler: HANDLER
+}
+
+interface InPageActionFunctionDefinition<NAME extends string, HANDLER> extends InPageFunctionDefinitionBase<NAME> {
+  type: 'action'
+  handler: HANDLER
+}
+
+type InPageFunctionDefinitionForType<
+  NAME extends string,
+  TYPE extends InPageFunctionType,
+  HANDLER,
+> = TYPE extends 'event'
+  ? InPageEventFunctionDefinition<NAME, HANDLER>
+  : TYPE extends 'action'
+    ? InPageActionFunctionDefinition<NAME, HANDLER>
+    : InPageQueryFunctionDefinition<NAME, HANDLER>
+
+type InPageFunctionDefinitionSchemas<
+  AS extends RpcArgsSchema | undefined,
+  RS extends RpcReturnSchema | undefined,
+> = [AS, RS] extends [undefined, undefined]
+  ? {
+      args?: AS
+      returns?: RS
+    }
+  : {
+      /** Standard Schema array validating (and typing) the arguments. */
+      args: AS
+      /** Standard Schema typing the resolved return value. */
+      returns: RS
+    }
+
+type InPageFunctionDefinitionHandler<
+  ARGS extends any[],
+  RETURN,
+  AS extends RpcArgsSchema | undefined,
+  RS extends RpcReturnSchema | undefined,
+> = [AS, RS] extends [undefined, undefined]
+  ? (...args: ARGS) => RETURN
+  : (...args: InferArgsType<AS>) => Thenable<InferReturnType<RS>>
+
 /**
  * An in-page channel function definition: the `defineRpcFunction` authoring
  * shape (`name`, `type`, Standard-Schema `args`/`returns`,
@@ -65,27 +119,11 @@ export type InPageFunctionDefinition<
   AS extends RpcArgsSchema | undefined = undefined,
   RS extends RpcReturnSchema | undefined = undefined,
 >
-  = [AS, RS] extends [undefined, undefined]
-    ? ({
-        name: NAME
-        type?: TYPE
-        args?: AS
-        returns?: RS
-        jsonSerializable?: boolean
-      } & (TYPE extends 'event'
-        ? { handler?: (...args: ARGS) => RETURN }
-        : { handler: (...args: ARGS) => RETURN }))
-    : ({
-        name: NAME
-        type?: TYPE
-        /** Standard Schema array validating (and typing) the arguments. */
-        args: AS
-        /** Standard Schema typing the resolved return value. */
-        returns: RS
-        jsonSerializable?: boolean
-      } & (TYPE extends 'event'
-        ? { handler?: (...args: InferArgsType<AS>) => Thenable<InferReturnType<RS>> }
-        : { handler: (...args: InferArgsType<AS>) => Thenable<InferReturnType<RS>> }))
+  = InPageFunctionDefinitionForType<
+    NAME,
+    TYPE,
+    InPageFunctionDefinitionHandler<ARGS, RETURN, AS, RS>
+  > & InPageFunctionDefinitionSchemas<AS, RS>
 
 /**
  * Loosely-typed definition used by the internal function registry.
@@ -107,15 +145,25 @@ interface InPageFunctionOptionBase {
   jsonSerializable?: boolean
 }
 
+interface InPageEventFunctionOption<F> extends InPageFunctionOptionBase {
+  type: 'event'
+  handler?: ProtocolHandler<F>
+}
+
+interface InPageQueryFunctionOption<F> extends InPageFunctionOptionBase {
+  type?: 'query'
+  handler: ProtocolHandler<F>
+}
+
+interface InPageActionFunctionOption<F> extends InPageFunctionOptionBase {
+  type: 'action'
+  handler: ProtocolHandler<F>
+}
+
 type InPageFunctionOption<F>
-  = | (InPageFunctionOptionBase & {
-    type: 'event'
-    handler?: ProtocolHandler<F>
-  })
-  | (InPageFunctionOptionBase & {
-    type?: Exclude<InPageFunctionType, 'event'>
-    handler: ProtocolHandler<F>
-  })
+  = | InPageEventFunctionOption<F>
+    | InPageQueryFunctionOption<F>
+    | InPageActionFunctionOption<F>
 
 /**
  * Functions implemented by {@link createPageScriptChannel}.

--- a/packages/devframe/src/in-page-channel/types.ts
+++ b/packages/devframe/src/in-page-channel/types.ts
@@ -134,12 +134,11 @@ export type InPageFunctionDefinition<
   RETURN = void,
   AS extends RpcArgsSchema | undefined = undefined,
   RS extends RpcReturnSchema | undefined = undefined,
->
-  = InPageFunctionDefinitionForType<
-    NAME,
-    TYPE,
-    InPageFunctionDefinitionHandler<ARGS, RETURN, AS, RS>
-  > & InPageFunctionDefinitionSchemas<AS, RS>
+> = InPageFunctionDefinitionForType<
+  NAME,
+  TYPE,
+  InPageFunctionDefinitionHandler<ARGS, RETURN, AS, RS>
+> & InPageFunctionDefinitionSchemas<AS, RS>
 
 /**
  * Loosely-typed definition used by the internal function registry.

--- a/packages/devframe/src/in-page-channel/types.ts
+++ b/packages/devframe/src/in-page-channel/types.ts
@@ -32,6 +32,22 @@ type FnArgs<F> = F extends (...args: infer A) => any ? A : never
 type FnReturn<F> = F extends (...args: any[]) => infer R ? Awaited<R> : never
 
 /**
+ * Page-script functions whose resolved return type marks an event.
+ * @internal
+ */
+type PageScriptFunctionsEvents<P extends InPageChannelProtocol> = {
+  [K in keyof PageScriptFunctions<P> as FnReturn<PageScriptFunctions<P>[K]> extends void ? K : never]: PageScriptFunctions<P>[K]
+}
+
+/**
+ * Panel functions whose resolved return type marks an event.
+ * @internal
+ */
+type PanelFunctionsEvents<P extends InPageChannelProtocol> = {
+  [K in keyof PanelFunctions<P> as FnReturn<PanelFunctions<P>[K]> extends void ? K : never]: PanelFunctions<P>[K]
+}
+
+/**
  * Converts a protocol function to its accepted endpoint handler.
  *
  * @internal
@@ -340,9 +356,9 @@ export interface PageScriptChannel<P extends InPageChannelProtocol> {
     ...args: FnArgs<PanelFunctions<P>[K]>
   ) => void
   /** Subscribe to an event emitted by a panel. Returns an unsubscribe function. */
-  on: <K extends keyof PageScriptFunctions<P> & string>(
+  on: <K extends keyof PageScriptFunctionsEvents<P> & string>(
     name: K,
-    listener: (...args: FnArgs<PageScriptFunctions<P>[K]>) => void,
+    listener: (...args: FnArgs<PageScriptFunctionsEvents<P>[K]>) => void,
   ) => () => void
   /** Page-script-authoritative shared states, replayed to joining panels. */
   readonly sharedState: InPageSharedStateHost<P>
@@ -397,9 +413,9 @@ export interface PanelChannel<P extends InPageChannelProtocol> {
     ...args: FnArgs<PageScriptFunctions<P>[K]>
   ) => void
   /** Subscribe to an event emitted by the page script. Returns an unsubscribe function. */
-  on: <K extends keyof PanelFunctions<P> & string>(
+  on: <K extends keyof PanelFunctionsEvents<P> & string>(
     name: K,
-    listener: (...args: FnArgs<PanelFunctions<P>[K]>) => void,
+    listener: (...args: FnArgs<PanelFunctionsEvents<P>[K]>) => void,
   ) => () => void
   /** Shared states mirrored from the page-script authority. */
   readonly sharedState: InPageSharedStateHost<P>

--- a/packages/devframe/src/in-page-channel/types.ts
+++ b/packages/devframe/src/in-page-channel/types.ts
@@ -346,14 +346,14 @@ export interface PageScriptChannel<P extends InPageChannelProtocol> {
   readonly panels: readonly PanelPeer<P>[]
   readonly events: Pick<EventEmitter<PageScriptChannelEvents<P>>, 'on' | 'once'>
   /** Fan an event out to every connected panel. */
-  emit: <K extends keyof PanelFunctions<P> & string>(
+  emit: <K extends keyof PanelFunctionsEvents<P> & string>(
     name: K,
-    ...args: FnArgs<PanelFunctions<P>[K]>
+    ...args: FnArgs<PanelFunctionsEvents<P>[K]>
   ) => void
   /** @deprecated Use `emit()` instead. */
-  callEvent: <K extends keyof PanelFunctions<P> & string>(
+  callEvent: <K extends keyof PanelFunctionsEvents<P> & string>(
     name: K,
-    ...args: FnArgs<PanelFunctions<P>[K]>
+    ...args: FnArgs<PanelFunctionsEvents<P>[K]>
   ) => void
   /** Subscribe to an event emitted by a panel. Returns an unsubscribe function. */
   on: <K extends keyof PageScriptFunctionsEvents<P> & string>(
@@ -403,14 +403,14 @@ export interface PanelChannel<P extends InPageChannelProtocol> {
    * Emit an event to the page script. While `connecting` the event is buffered
    * (up to `eventBufferLimit`) and flushed on connect.
    */
-  emit: <K extends keyof PageScriptFunctions<P> & string>(
+  emit: <K extends keyof PageScriptFunctionsEvents<P> & string>(
     name: K,
-    ...args: FnArgs<PageScriptFunctions<P>[K]>
+    ...args: FnArgs<PageScriptFunctionsEvents<P>[K]>
   ) => void
   /** @deprecated Use `emit()` instead. */
-  callEvent: <K extends keyof PageScriptFunctions<P> & string>(
+  callEvent: <K extends keyof PageScriptFunctionsEvents<P> & string>(
     name: K,
-    ...args: FnArgs<PageScriptFunctions<P>[K]>
+    ...args: FnArgs<PageScriptFunctionsEvents<P>[K]>
   ) => void
   /** Subscribe to an event emitted by the page script. Returns an unsubscribe function. */
   on: <K extends keyof PanelFunctionsEvents<P> & string>(

--- a/plugins/a11y/app/lib/channel.ts
+++ b/plugins/a11y/app/lib/channel.ts
@@ -71,16 +71,16 @@ export function createA11yChannel(): A11yChannel {
     pageScriptReady,
     scanning: () => state()?.scanning || localScanning(),
     activeRoute: () => state()?.activeRoute ?? null,
-    preview: node => channel.callEvent('highlight', node.id, node.target),
-    clearPreview: () => channel.callEvent('clear-highlight'),
-    setPins: pins => channel.callEvent('set-pins', pins),
+    preview: node => channel.emit('highlight', node.id, node.target),
+    clearPreview: () => channel.emit('clear-highlight'),
+    setPins: pins => channel.emit('set-pins', pins),
     rescan: () => {
       setLocalScanning(true)
-      channel.callEvent('rescan')
+      channel.emit('rescan')
     },
-    sendConfig: config => channel.callEvent('set-config', config),
-    setAutoScan: enabled => channel.callEvent('set-autoscan', enabled),
-    clearRoute: route => channel.callEvent('clear-route', route),
-    clearAll: () => channel.callEvent('clear-all'),
+    sendConfig: config => channel.emit('set-config', config),
+    setAutoScan: enabled => channel.emit('set-autoscan', enabled),
+    clearRoute: route => channel.emit('clear-route', route),
+    clearAll: () => channel.emit('clear-all'),
   }
 }

--- a/tests/__snapshots__/tsnapi/devframe/in-page-channel.snapshot.d.ts
+++ b/tests/__snapshots__/tsnapi/devframe/in-page-channel.snapshot.d.ts
@@ -3,7 +3,7 @@
  */
 // #region Interfaces
 export interface ConnectPanelChannelOptions<Protocol extends InPageChannelProtocol = InPageChannelProtocol> extends InPageChannelCommonOptions {
-  functions?: ConnectPanelChannelOptionsFunctions<Protocol>;
+  functions: ConnectPanelChannelOptionsFunctions<Protocol>;
   window?: Window | false;
   targets?: Window[];
   transport?: MessagePort;
@@ -12,7 +12,7 @@ export interface ConnectPanelChannelOptions<Protocol extends InPageChannelProtoc
   eventBufferLimit?: number;
 }
 export interface CreatePageScriptChannelOptions<Protocol extends InPageChannelProtocol = InPageChannelProtocol> extends InPageChannelCommonOptions {
-  functions?: CreatePageScriptChannelOptionsFunctions<Protocol>;
+  functions: CreatePageScriptChannelOptionsFunctions<Protocol>;
   window?: Window | false;
 }
 export interface InPageChannelProtocol {
@@ -62,21 +62,27 @@ export type InPageChannelErrorCode = 'timeout' |
 'invalid-args' |
 'state-uninitialized';
 export type InPageChannelStatus = 'connecting' | 'connected' | 'closed';
-export type InPageFunctionDefinition<NAME extends string, TYPE extends InPageFunctionType = 'query', ARGS extends any[] = [], RETURN = void, AS extends RpcArgsSchema | undefined = undefined, RS extends RpcReturnSchema | undefined = undefined> = [AS, RS] extends [undefined, undefined] ? {
+export type InPageFunctionDefinition<NAME extends string, TYPE extends InPageFunctionType = 'query', ARGS extends any[] = [], RETURN = void, AS extends RpcArgsSchema | undefined = undefined, RS extends RpcReturnSchema | undefined = undefined> = [AS, RS] extends [undefined, undefined] ? ({
   name: NAME;
   type?: TYPE;
   args?: AS;
   returns?: RS;
   jsonSerializable?: boolean;
-  handler: (...args: ARGS) => RETURN;
+} & (TYPE extends 'event' ? {
+  handler?: (...args: ARGS) => RETURN;
 } : {
+  handler: (...args: ARGS) => RETURN;
+})) : ({
   name: NAME;
   type?: TYPE;
   args: AS;
   returns: RS;
   jsonSerializable?: boolean;
+} & (TYPE extends 'event' ? {
+  handler?: (...args: InferArgsType<AS>) => Thenable<InferReturnType<RS>>;
+} : {
   handler: (...args: InferArgsType<AS>) => Thenable<InferReturnType<RS>>;
-};
+}));
 // #endregion
 
 // #region Classes
@@ -92,12 +98,12 @@ export declare class InPageChannelError extends Error {
 // #region Functions
 export declare function connectPanelChannel<P extends InPageChannelProtocol>(_: ConnectPanelChannelOptions<P>): PanelChannel<P>;
 export declare function createPageScriptChannel<P extends InPageChannelProtocol>(_: CreatePageScriptChannelOptions<P>): PageScriptChannel<P>;
-export declare function defineChannelFunction<NAME extends string, TYPE extends InPageFunctionType, ARGS extends any[], RETURN = void, const AS extends RpcArgsSchema | undefined = undefined, const RS extends RpcReturnSchema | undefined = undefined>(_: InPageFunctionDefinition<NAME, TYPE, ARGS, RETURN, AS, RS>): InPageFunctionDefinition<NAME, TYPE, ARGS, RETURN, AS, RS>;
+export declare function defineChannelFunction<NAME extends string, TYPE extends InPageFunctionType, ARGS extends any[] = [], RETURN = void, const AS extends RpcArgsSchema | undefined = undefined, const RS extends RpcReturnSchema | undefined = undefined>(_: InPageFunctionDefinition<NAME, TYPE, ARGS, RETURN, AS, RS>): InPageFunctionDefinition<NAME, TYPE, ARGS, RETURN, AS, RS>;
 // #endregion
 
 // #region Referenced (internal)
-type ConnectPanelChannelOptionsFunctions<P extends InPageChannelProtocol> = Partial<{ [NAME in keyof PanelFunctions<P> & string]: InPageFunctionOption<PanelFunctions<P>[NAME]>; }>;
-type CreatePageScriptChannelOptionsFunctions<P extends InPageChannelProtocol> = Partial<{ [NAME in keyof PageScriptFunctions<P> & string]: InPageFunctionOption<PageScriptFunctions<P>[NAME]>; }>;
+type ConnectPanelChannelOptionsFunctions<P extends InPageChannelProtocol> = { [NAME in keyof PanelFunctions<P> & string]: InPageFunctionOption<PanelFunctions<P>[NAME]>; };
+type CreatePageScriptChannelOptionsFunctions<P extends InPageChannelProtocol> = { [NAME in keyof PageScriptFunctions<P> & string]: InPageFunctionOption<PageScriptFunctions<P>[NAME]>; };
 type FnArgs<F> = F extends ((...args: infer A) => any) ? A : never;
 type FnReturn<F> = F extends ((...args: any[]) => infer R) ? Awaited<R> : never;
 interface InPageChannelCommonOptions {

--- a/tests/__snapshots__/tsnapi/devframe/in-page-channel.snapshot.d.ts
+++ b/tests/__snapshots__/tsnapi/devframe/in-page-channel.snapshot.d.ts
@@ -62,27 +62,7 @@ export type InPageChannelErrorCode = 'timeout' |
 'invalid-args' |
 'state-uninitialized';
 export type InPageChannelStatus = 'connecting' | 'connected' | 'closed';
-export type InPageFunctionDefinition<NAME extends string, TYPE extends InPageFunctionType = 'query', ARGS extends any[] = [], RETURN = void, AS extends RpcArgsSchema | undefined = undefined, RS extends RpcReturnSchema | undefined = undefined> = [AS, RS] extends [undefined, undefined] ? ({
-  name: NAME;
-  type?: TYPE;
-  args?: AS;
-  returns?: RS;
-  jsonSerializable?: boolean;
-} & (TYPE extends 'event' ? {
-  handler?: (...args: ARGS) => RETURN;
-} : {
-  handler: (...args: ARGS) => RETURN;
-})) : ({
-  name: NAME;
-  type?: TYPE;
-  args: AS;
-  returns: RS;
-  jsonSerializable?: boolean;
-} & (TYPE extends 'event' ? {
-  handler?: (...args: InferArgsType<AS>) => Thenable<InferReturnType<RS>>;
-} : {
-  handler: (...args: InferArgsType<AS>) => Thenable<InferReturnType<RS>>;
-}));
+export type InPageFunctionDefinition<NAME extends string, TYPE extends InPageFunctionType = 'query', ARGS extends any[] = [], RETURN = void, AS extends RpcArgsSchema | undefined = undefined, RS extends RpcReturnSchema | undefined = undefined> = InPageFunctionDefinitionForType<NAME, TYPE, InPageFunctionDefinitionHandler<ARGS, RETURN, AS, RS>> & InPageFunctionDefinitionSchemas<AS, RS>;
 // #endregion
 
 // #region Classes
@@ -98,7 +78,7 @@ export declare class InPageChannelError extends Error {
 // #region Functions
 export declare function connectPanelChannel<P extends InPageChannelProtocol>(_: ConnectPanelChannelOptions<P>): PanelChannel<P>;
 export declare function createPageScriptChannel<P extends InPageChannelProtocol>(_: CreatePageScriptChannelOptions<P>): PageScriptChannel<P>;
-export declare function defineChannelFunction<NAME extends string, TYPE extends InPageFunctionType, ARGS extends any[] = [], RETURN = void, const AS extends RpcArgsSchema | undefined = undefined, const RS extends RpcReturnSchema | undefined = undefined>(_: InPageFunctionDefinition<NAME, TYPE, ARGS, RETURN, AS, RS>): InPageFunctionDefinition<NAME, TYPE, ARGS, RETURN, AS, RS>;
+export declare function defineChannelFunction<NAME extends string, TYPE extends InPageFunctionType, ARGS extends any[], RETURN = void, const AS extends RpcArgsSchema | undefined = undefined, const RS extends RpcReturnSchema | undefined = undefined>(_: InPageFunctionDefinition<NAME, TYPE, ARGS, RETURN, AS, RS>): InPageFunctionDefinition<NAME, TYPE, ARGS, RETURN, AS, RS>;
 // #endregion
 
 // #region Referenced (internal)
@@ -117,6 +97,15 @@ interface InPageChannelCommonOptions {
   serialize?: (_: unknown) => unknown;
   deserialize?: (_: unknown) => unknown;
 }
+type InPageFunctionDefinitionForType<NAME extends string, TYPE extends InPageFunctionType, HANDLER> = TYPE extends 'event' ? InPageEventFunctionDefinition<NAME, HANDLER> : TYPE extends 'action' ? InPageActionFunctionDefinition<NAME, HANDLER> : InPageQueryFunctionDefinition<NAME, HANDLER>;
+type InPageFunctionDefinitionHandler<ARGS extends any[], RETURN, AS extends RpcArgsSchema | undefined, RS extends RpcReturnSchema | undefined> = [AS, RS] extends [undefined, undefined] ? (...args: ARGS) => RETURN : (...args: InferArgsType<AS>) => Thenable<InferReturnType<RS>>;
+type InPageFunctionDefinitionSchemas<AS extends RpcArgsSchema | undefined, RS extends RpcReturnSchema | undefined> = [AS, RS] extends [undefined, undefined] ? {
+  args?: AS;
+  returns?: RS;
+} : {
+  args: AS;
+  returns: RS;
+};
 type InPageFunctionType = 'action' | 'event' | 'query';
 interface InPageSharedStateHost<P extends InPageChannelProtocol> {
   get: <K extends keyof SharedStates<P> & string>(_: K, _?: {

--- a/tests/__snapshots__/tsnapi/devframe/in-page-channel.snapshot.d.ts
+++ b/tests/__snapshots__/tsnapi/devframe/in-page-channel.snapshot.d.ts
@@ -3,7 +3,7 @@
  */
 // #region Interfaces
 export interface ConnectPanelChannelOptions<Protocol extends InPageChannelProtocol = InPageChannelProtocol> extends InPageChannelCommonOptions {
-  functions: ConnectPanelChannelOptionsFunctions<Protocol>;
+  functions?: ConnectPanelChannelOptionsFunctions<Protocol>;
   window?: Window | false;
   targets?: Window[];
   transport?: MessagePort;
@@ -12,7 +12,7 @@ export interface ConnectPanelChannelOptions<Protocol extends InPageChannelProtoc
   eventBufferLimit?: number;
 }
 export interface CreatePageScriptChannelOptions<Protocol extends InPageChannelProtocol = InPageChannelProtocol> extends InPageChannelCommonOptions {
-  functions: CreatePageScriptChannelOptionsFunctions<Protocol>;
+  functions?: CreatePageScriptChannelOptionsFunctions<Protocol>;
   window?: Window | false;
 }
 export interface InPageChannelProtocol {
@@ -25,7 +25,9 @@ export interface PageScriptChannel<P extends InPageChannelProtocol> {
   readonly instanceId: string;
   readonly panels: readonly PanelPeer<P>[];
   readonly events: Pick<EventEmitter<PageScriptChannelEvents<P>>, 'on' | 'once'>;
+  emit: <K extends keyof PanelFunctions<P> & string>(_: K, ..._: FnArgs<PanelFunctions<P>[K]>) => void;
   callEvent: <K extends keyof PanelFunctions<P> & string>(_: K, ..._: FnArgs<PanelFunctions<P>[K]>) => void;
+  on: <K extends keyof PageScriptFunctions<P> & string>(_: K, _: (..._: FnArgs<PageScriptFunctions<P>[K]>) => void) => () => void;
   readonly sharedState: InPageSharedStateHost<P>;
   addPanelPort: (_: MessagePort) => PanelPeer<P>;
   close: () => void;
@@ -39,7 +41,9 @@ export interface PanelChannel<P extends InPageChannelProtocol> {
   readonly events: Pick<EventEmitter<PanelChannelEvents>, 'on' | 'once'>;
   whenConnected: (_?: number) => Promise<void>;
   call: <K extends keyof PageScriptFunctions<P> & string>(_: K, ..._: FnArgs<PageScriptFunctions<P>[K]>) => Promise<FnReturn<PageScriptFunctions<P>[K]>>;
+  emit: <K extends keyof PageScriptFunctions<P> & string>(_: K, ..._: FnArgs<PageScriptFunctions<P>[K]>) => void;
   callEvent: <K extends keyof PageScriptFunctions<P> & string>(_: K, ..._: FnArgs<PageScriptFunctions<P>[K]>) => void;
+  on: <K extends keyof PanelFunctions<P> & string>(_: K, _: (..._: FnArgs<PanelFunctions<P>[K]>) => void) => () => void;
   readonly sharedState: InPageSharedStateHost<P>;
   close: () => void;
 }
@@ -92,8 +96,8 @@ export declare function defineChannelFunction<NAME extends string, TYPE extends 
 // #endregion
 
 // #region Referenced (internal)
-type ConnectPanelChannelOptionsFunctions<P extends InPageChannelProtocol> = { [NAME in keyof PanelFunctions<P> & string]: InPageFunctionOption<PanelFunctions<P>[NAME]>; };
-type CreatePageScriptChannelOptionsFunctions<P extends InPageChannelProtocol> = { [NAME in keyof PageScriptFunctions<P> & string]: InPageFunctionOption<PageScriptFunctions<P>[NAME]>; };
+type ConnectPanelChannelOptionsFunctions<P extends InPageChannelProtocol> = Partial<{ [NAME in keyof PanelFunctions<P> & string]: InPageFunctionOption<PanelFunctions<P>[NAME]>; }>;
+type CreatePageScriptChannelOptionsFunctions<P extends InPageChannelProtocol> = Partial<{ [NAME in keyof PageScriptFunctions<P> & string]: InPageFunctionOption<PageScriptFunctions<P>[NAME]>; }>;
 type FnArgs<F> = F extends ((...args: infer A) => any) ? A : never;
 type FnReturn<F> = F extends ((...args: any[]) => infer R) ? Awaited<R> : never;
 interface InPageChannelCommonOptions {

--- a/tests/__snapshots__/tsnapi/devframe/in-page-channel.snapshot.d.ts
+++ b/tests/__snapshots__/tsnapi/devframe/in-page-channel.snapshot.d.ts
@@ -25,8 +25,8 @@ export interface PageScriptChannel<P extends InPageChannelProtocol> {
   readonly instanceId: string;
   readonly panels: readonly PanelPeer<P>[];
   readonly events: Pick<EventEmitter<PageScriptChannelEvents<P>>, 'on' | 'once'>;
-  emit: <K extends keyof PanelFunctions<P> & string>(_: K, ..._: FnArgs<PanelFunctions<P>[K]>) => void;
-  callEvent: <K extends keyof PanelFunctions<P> & string>(_: K, ..._: FnArgs<PanelFunctions<P>[K]>) => void;
+  emit: <K extends keyof PanelFunctionsEvents<P> & string>(_: K, ..._: FnArgs<PanelFunctionsEvents<P>[K]>) => void;
+  callEvent: <K extends keyof PanelFunctionsEvents<P> & string>(_: K, ..._: FnArgs<PanelFunctionsEvents<P>[K]>) => void;
   on: <K extends keyof PageScriptFunctionsEvents<P> & string>(_: K, _: (..._: FnArgs<PageScriptFunctionsEvents<P>[K]>) => void) => () => void;
   readonly sharedState: InPageSharedStateHost<P>;
   addPanelPort: (_: MessagePort) => PanelPeer<P>;
@@ -41,8 +41,8 @@ export interface PanelChannel<P extends InPageChannelProtocol> {
   readonly events: Pick<EventEmitter<PanelChannelEvents>, 'on' | 'once'>;
   whenConnected: (_?: number) => Promise<void>;
   call: <K extends keyof PageScriptFunctions<P> & string>(_: K, ..._: FnArgs<PageScriptFunctions<P>[K]>) => Promise<FnReturn<PageScriptFunctions<P>[K]>>;
-  emit: <K extends keyof PageScriptFunctions<P> & string>(_: K, ..._: FnArgs<PageScriptFunctions<P>[K]>) => void;
-  callEvent: <K extends keyof PageScriptFunctions<P> & string>(_: K, ..._: FnArgs<PageScriptFunctions<P>[K]>) => void;
+  emit: <K extends keyof PageScriptFunctionsEvents<P> & string>(_: K, ..._: FnArgs<PageScriptFunctionsEvents<P>[K]>) => void;
+  callEvent: <K extends keyof PageScriptFunctionsEvents<P> & string>(_: K, ..._: FnArgs<PageScriptFunctionsEvents<P>[K]>) => void;
   on: <K extends keyof PanelFunctionsEvents<P> & string>(_: K, _: (..._: FnArgs<PanelFunctionsEvents<P>[K]>) => void) => () => void;
   readonly sharedState: InPageSharedStateHost<P>;
   close: () => void;

--- a/tests/__snapshots__/tsnapi/devframe/in-page-channel.snapshot.d.ts
+++ b/tests/__snapshots__/tsnapi/devframe/in-page-channel.snapshot.d.ts
@@ -27,7 +27,7 @@ export interface PageScriptChannel<P extends InPageChannelProtocol> {
   readonly events: Pick<EventEmitter<PageScriptChannelEvents<P>>, 'on' | 'once'>;
   emit: <K extends keyof PanelFunctions<P> & string>(_: K, ..._: FnArgs<PanelFunctions<P>[K]>) => void;
   callEvent: <K extends keyof PanelFunctions<P> & string>(_: K, ..._: FnArgs<PanelFunctions<P>[K]>) => void;
-  on: <K extends keyof PageScriptFunctions<P> & string>(_: K, _: (..._: FnArgs<PageScriptFunctions<P>[K]>) => void) => () => void;
+  on: <K extends keyof PageScriptFunctionsEvents<P> & string>(_: K, _: (..._: FnArgs<PageScriptFunctionsEvents<P>[K]>) => void) => () => void;
   readonly sharedState: InPageSharedStateHost<P>;
   addPanelPort: (_: MessagePort) => PanelPeer<P>;
   close: () => void;
@@ -43,7 +43,7 @@ export interface PanelChannel<P extends InPageChannelProtocol> {
   call: <K extends keyof PageScriptFunctions<P> & string>(_: K, ..._: FnArgs<PageScriptFunctions<P>[K]>) => Promise<FnReturn<PageScriptFunctions<P>[K]>>;
   emit: <K extends keyof PageScriptFunctions<P> & string>(_: K, ..._: FnArgs<PageScriptFunctions<P>[K]>) => void;
   callEvent: <K extends keyof PageScriptFunctions<P> & string>(_: K, ..._: FnArgs<PageScriptFunctions<P>[K]>) => void;
-  on: <K extends keyof PanelFunctions<P> & string>(_: K, _: (..._: FnArgs<PanelFunctions<P>[K]>) => void) => () => void;
+  on: <K extends keyof PanelFunctionsEvents<P> & string>(_: K, _: (..._: FnArgs<PanelFunctionsEvents<P>[K]>) => void) => () => void;
   readonly sharedState: InPageSharedStateHost<P>;
   close: () => void;
 }
@@ -117,8 +117,10 @@ interface PageScriptChannelEvents<P extends InPageChannelProtocol> {
   'panel:disconnected': (_: PanelPeer<P>) => void;
 }
 type PageScriptFunctions<P extends InPageChannelProtocol> = SideFunctions<NonNullable<P['pageScript']>>;
+type PageScriptFunctionsEvents<P extends InPageChannelProtocol> = { [K in keyof PageScriptFunctions<P> as FnReturn<PageScriptFunctions<P>[K]> extends void ? K : never]: PageScriptFunctions<P>[K]; };
 interface PanelChannelEvents {
   'status:updated': (_: InPageChannelStatus) => void;
 }
 type PanelFunctions<P extends InPageChannelProtocol> = SideFunctions<NonNullable<P['panel']>>;
+type PanelFunctionsEvents<P extends InPageChannelProtocol> = { [K in keyof PanelFunctions<P> as FnReturn<PanelFunctions<P>[K]> extends void ? K : never]: PanelFunctions<P>[K]; };
 // #endregion


### PR DESCRIPTION
I realized that I need to listen to events dynamically, so the current setup doesn't work. I also noticed that callEvent could use a better name like `emit()` 


- `channel.emit()` + `channel.on()`; `on()` returns an unsubscribe function.
- Allow declared `type: 'event'` functions to omit `handler`
- Keep `callEvent()` as a deprecated compatibility alias.

This makes me think that `channel.events` might also be a bit confusing right now, I did try to go for this initially

Another thought: this implementation infer events from the types directly: functions that return `void`. **This is not correct as an action can return void and just be used to catch errors or timeouts**. I think this PR is big enough to leave that to another one but here are 2 possibilities:

- Adding a different `events` property (and maybe reworking the shape of `InPageChannelProtocol` to also have `functions`):
 
  ```ts
  interface InPageChannelProtocol {
    functions: {
      /** Functions implemented by the page script. */
      pageScript?: Record<string, (...args: any[]) => any>
      /** Functions received by panels. */
      panel?: Record<string, (...args: any[]) => any>
    },
  
    events: {
      /**
       * Events emitted by the panel and listened on by the page script.
       */
      pageScript?: Record<string, (...args: any[]) => any>
      /**
       * Events emitted by the page script and listened on by the panel.
       */
      panel?: Record<string, (...args: any[]) => any>
  
    }
  
    /**
     * Shared-state slots. The page script is the authority: it owns the
     * canonical value; panels are seeded on connect and converge through
     * syncId-deduplicated patches.
     */
    sharedStates?: Record<string, object>
  }
  ```
  
- A type marker:

  ```ts
  pageScript: {
    // event if void
    save: (value: string) => void
    // explicit action that returns void
    reset: InPageAction<() => void>
  }
  ```