### PR TITLE
fix(git): restore dark theme foreground colors

### DIFF
--- a/plugins/git/app/components/dashboard.tsx
+++ b/plugins/git/app/components/dashboard.tsx
@@ -181,7 +181,7 @@ function DashboardBody() {
   const showCommitDetails = pane === 'commits' && selectedCommit !== null
 
   return (
-    <div className="bg-base flex h-svh w-full flex-col overflow-hidden">
+    <div className="bg-base color-base flex h-svh w-full flex-col overflow-hidden">
       <header className={navBar()}>
         <div className={navBrand()}>
           <Icon name="i-ph-git-fork-duotone" className="text-base color-active" />


### PR DESCRIPTION
The Git dashboard's theme toggle, brand label, heading, and refresh icon inherit black foreground colors in dark mode, making them difficult to see against the dark background. This reproduces in both Vite DevTools and Devframe Hub.

Add `color-base` to the dashboard root alongside `bg-base`, matching Data Inspector's explicit foreground baseline. Descendants now inherit the appropriate theme color. The existing sun-in-light / moon-in-dark icon behavior is preserved.

Validation:

- Browser verification of light and dark themes in the embedded panel and standalone SPA: theme icons and headings remain visible.
- `pnpm lint`, `pnpm knip`, `pnpm typecheck`, and `pnpm build`: passed.
- Full Vitest run: 128 files passed; 1457 tests passed and 9 skipped. The initial run found duplicate declarations left in `dist`; `pnpm -C packages/devframe build` cleared those artifacts, and `pnpm exec vitest run` then passed.
