### PR TITLE
fix(hub-ui): prevent popup dock rails from scrolling out of view

### DIFF
--- a/packages/hub-ui/src/client/components/dock/DockStandalone.vue
+++ b/packages/hub-ui/src/client/components/dock/DockStandalone.vue
@@ -52,7 +52,7 @@ function switchEntry(id: string | undefined) {
     <div v-if="!isRpcTrusted" class="h-screen w-screen of-hidden">
       <ViewBuiltinClientAuthNotice :context="context" />
     </div>
-    <div v-else class="h-screen w-screen of-hidden grid cols-[max-content_1fr]">
+    <div v-else class="h-screen w-screen of-clip grid cols-[max-content_1fr]">
       <div class="border-r border-base flex flex-col min-h-0">
         <div class="p2 border-b border-base flex">
           <BrandMark class="w-7 h-7 ma" />
@@ -79,7 +79,7 @@ function switchEntry(id: string | undefined) {
           :group="activeGroup"
           :selected-id="context.docks.selected?.id ?? null"
         />
-        <div class="relative flex-1 min-w-0 min-h-0">
+        <div class="relative flex-1 min-w-0 min-h-0 of-clip">
           <ViewEntry
             v-if="context.docks.selected && panes"
             :key="context.docks.selected.id"


### PR DESCRIPTION
## Problem

In the popup dock, opening an ungrouped dock entry such as UnoCSS before switching to Vite+ → Vite or Rolldown → Modules Graph → Graph can scroll the entire layout left and move the primary dock rail out of view. Opening Graph directly does not reproduce the same overflow. The standalone viewer uses the same `DockStandalone` component and is also affected.

Inactive iframe panes retain their previous dimensions. Adding the 48px group sidebar narrows the active content viewport, while the previously opened pane remains 48px wider. That pane's overflow reaches the outer grid, where `overflow: hidden` still permits programmatic scrolling. Graph's node-centering `scrollIntoView()` can then scroll the dock layout along with the graph.

## Fix

Use `overflow: clip` on the outer `DockStandalone` grid and its sized content viewport. The content boundary contains retained panes, and the outer boundary keeps the dock rails anchored. Iframe state, retained dimensions, and scrolling inside each panel are preserved.

This extends the containment approach used for edge mode in #220 and #255 to the layout shared by popup and standalone views. The change is limited to two class edits in `DockStandalone.vue`.

## Verification

- `pnpm lint` — passed.
- `pnpm knip` — passed.
- `pnpm test` — 128 test files passed; 1457 tests passed, 9 skipped.
- `pnpm typecheck` — passed.
- `pnpm build` — passed.
- Chrome reproduction before the fix: the standalone grid had `clientWidth=1210`, `scrollWidth=1258`, and changed from `scrollLeft=0` to `48` after opening Graph.
- Chrome verification with the rebuilt Hub UI against the same Vite DevTools playground: the standalone grid remained at `scrollLeft=0` with no horizontal overflow after UnoCSS → Vite Graph and List → Graph. The inactive iframe retained its wider dimensions, and list content still scrolled internally.
- Popup verification: UnoCSS → Vite+ → an existing Rolldown build session → Modules Graph retained both dock rails in view.

The browser regression was checked interactively; no new automated browser test was added.
