### PR TITLE
perf: avoid discarded replay and scrollback splice results

### DIFF
--- a/packages/devframe/src/utils/streaming-channel.test.ts
+++ b/packages/devframe/src/utils/streaming-channel.test.ts
@@ -61,6 +61,25 @@ describe('streaming-channel sink', () => {
     expect(sink.buffer.length).toBe(0)
   })
 
+  it.each([
+    { replayWindow: 1, retained: [5] },
+    { replayWindow: 3, retained: [3, 4, 5] },
+    { replayWindow: 0.5, retained: [5] },
+    { replayWindow: 2.5, retained: [3, 4, 5] },
+    { replayWindow: Number.POSITIVE_INFINITY, retained: [1, 2, 3, 4, 5] },
+    { replayWindow: Number.NaN, retained: [] },
+  ])('preserves replay entries and buffer identity with window $replayWindow', ({ replayWindow, retained }) => {
+    const sink = createStreamSink<number>({ replayWindow })
+    const buffer = sink.buffer
+    for (let chunk = 1; chunk <= 5; chunk++)
+      sink.write(chunk)
+
+    expect(sink.buffer).toBe(buffer)
+    expect(buffer).toEqual(retained.map(chunk => ({ seq: chunk, chunk })))
+    expect(sink.lastSeq).toBe(5)
+    sink.close()
+  })
+
   it('aborts signal on close so handlers can short-circuit', () => {
     const sink = createStreamSink<string>()
     expect(sink.signal.aborted).toBe(false)

--- a/packages/devframe/src/utils/streaming-channel.ts
+++ b/packages/devframe/src/utils/streaming-channel.ts
@@ -151,8 +151,12 @@ export function createStreamSink<T>(options: CreateStreamSinkOptions = {}): Stre
     lastSeq += 1
     if (replayWindow > 0) {
       buffer.push({ seq: lastSeq, chunk })
-      if (buffer.length > replayWindow)
-        buffer.splice(0, buffer.length - replayWindow)
+      if (buffer.length > replayWindow) {
+        if (buffer.length - replayWindow === 1)
+          buffer.shift()
+        else
+          buffer.splice(0, buffer.length - replayWindow)
+      }
     }
     events.emit('chunk', lastSeq, chunk)
   }

--- a/packages/hub/src/node/__tests__/host-terminals.test.ts
+++ b/packages/hub/src/node/__tests__/host-terminals.test.ts
@@ -179,6 +179,55 @@ describe('devframeTerminalHost stream lifecycle', () => {
     expect(session.buffer!.includes('line-0')).toBe(false)
   })
 
+  it('evicts one scrollback chunk without producing discarded splice results', async () => {
+    const { host, sinks } = createTerminalHost()
+    const buffer: string[] = []
+    const splice = vi.spyOn(buffer, 'splice')
+    const chunks = Array.from({ length: 1200 }, (_, i) => `line-${i}`)
+    const stream = new ReadableStream<string>({
+      start(controller) {
+        for (const chunk of chunks)
+          controller.enqueue(chunk)
+        controller.close()
+      },
+    })
+    const session: DevframeTerminalSession = { id: 't', title: 'T', status: 'running', stream, buffer }
+    host.register(session)
+    try {
+      await waitUntil(() => expect(sinks.get('t')?.closed).toBe(true))
+      expect(session.buffer).toBe(buffer)
+      expect([...buffer]).toEqual(chunks.slice(-1000))
+      expect(sinks.get('t')?.write.mock.calls).toEqual(chunks.map(chunk => [chunk]))
+      expect(splice).not.toHaveBeenCalled()
+    }
+    finally {
+      splice.mockRestore()
+      host.remove(session)
+    }
+  })
+
+  it('trims an oversized supplied scrollback buffer on the next chunk', async () => {
+    const { host, sinks } = createTerminalHost()
+    const buffer = Array.from({ length: 1500 }, (_, i) => `line-${i}`)
+    const expected = [...buffer, 'latest'].slice(-1000)
+    const stream = new ReadableStream<string>({
+      start(controller) {
+        controller.enqueue('latest')
+        controller.close()
+      },
+    })
+    const session: DevframeTerminalSession = { id: 't', title: 'T', status: 'running', stream, buffer }
+    host.register(session)
+    try {
+      await waitUntil(() => expect(sinks.get('t')?.closed).toBe(true))
+      expect(session.buffer).toBe(buffer)
+      expect(buffer).toEqual(expected)
+    }
+    finally {
+      host.remove(session)
+    }
+  })
+
   it('rejects restarting a terminated child-process session', async () => {
     const { host, sinks } = createTerminalHost()
     const session = await host.startChildProcess(

--- a/packages/hub/src/node/host-terminals.ts
+++ b/packages/hub/src/node/host-terminals.ts
@@ -159,7 +159,9 @@ export class DevframeTerminalsHost implements DevframeTerminalsHostType {
         // Mirror to the legacy session.buffer used by `terminals:read`:
         // a bounded tail kept for the snapshot endpoint.
         sessionBuffer.push(result.value)
-        if (sessionBuffer.length > TERMINAL_BUFFER_LIMIT)
+        if (sessionBuffer.length === TERMINAL_BUFFER_LIMIT + 1)
+          sessionBuffer.shift()
+        else if (sessionBuffer.length > TERMINAL_BUFFER_LIMIT)
           sessionBuffer.splice(0, sessionBuffer.length - TERMINAL_BUFFER_LIMIT)
         sink?.write(result.value)
       }


### PR DESCRIPTION
After their buffers fill, RPC replay and terminal scrollback discard an array returned by `splice` on each new chunk. Use `shift` when exactly one entry must be removed. Keep `splice` for other overflows, including fractional replay windows and oversized supplied scrollback buffers.

```diff
 buffer exceeds its limit by one
-  splice(0, 1), discard the returned array
+  shift()
 other overflow values
   keep splice()
```

For each buffer, 10,000 writes with a 1,000-entry limit produce 9,000 discarded splice results before and 0 after. The retained entries, order, and buffer identity stay the same.

| Reproduction | Before | After |
| --- | --- | --- |
| RPC replay | [Before](https://github.com/onmax/repros/tree/repro/devframe-replay-buffer-eviction/devframe-replay-buffer-eviction) | [After](https://github.com/onmax/repros/tree/repro/devframe-replay-buffer-eviction/devframe-replay-buffer-eviction-fix) |
| Terminal scrollback | [Before](https://github.com/onmax/repros/tree/repro/devframe-terminal-scrollback/devframe-terminal-scrollback) | [After](https://github.com/onmax/repros/tree/repro/devframe-terminal-scrollback/devframe-terminal-scrollback-fix) |

Run locally on Node 24.19.0 with Corepack. Each pair tests the same published package version with and without a committed package patch. The terminal fixture drives the real stream pump with a recording sink; it does not spawn a PTY.

<details>
<summary>Copy and run both comparisons</summary>

```sh
for repro in devframe-replay-buffer-eviction devframe-terminal-scrollback; do
  (
    set -e
    git clone --depth 1 --filter=blob:none --sparse --branch "repro/$repro" https://github.com/onmax/repros.git "$repro-repro"
    cd "$repro-repro"
    git sparse-checkout set "$repro" "$repro-fix"
    cd "$repro"
    corepack pnpm install --frozen-lockfile --ignore-scripts
    corepack pnpm verify
    cd "../$repro-fix"
    corepack pnpm install --frozen-lockfile --ignore-scripts
    corepack pnpm verify
  ) || exit 1
done
```

</details>
