### PR TITLE
perf(shared-state): skip unchanged mutation notifications

### DIFF
--- a/docs/content/1.guide/4.shared-state.md
+++ b/docs/content/1.guide/4.shared-state.md
@@ -72,7 +72,7 @@ state.mutate((draft) => {
 })
 ```
 
-Devframe applies the recipe to a draft, emits `updated` (with `SharedStatePatch[]` if enabled), and broadcasts to RPC clients; a `syncIds` set keeps mutations idempotent on replay.
+Devframe applies the recipe to a draft. When Immer returns a new state reference, Devframe emits `updated` and broadcasts it to RPC clients. Explicit replacement objects also notify. With patches enabled, `updated` carries `SharedStatePatch[]`. Sync IDs remain recorded for unchanged recipes, so replays stay idempotent.
 
 ## Patches (advanced)
 

--- a/packages/devframe/src/client/rpc-shared-state.test.ts
+++ b/packages/devframe/src/client/rpc-shared-state.test.ts
@@ -20,6 +20,22 @@ function makeFakeRpc() {
 }
 
 describe('client shared state', () => {
+  it('does not forward unchanged writes to the RPC server', async () => {
+    const { rpc, events, setCalls } = makeFakeRpc()
+    const state = await createRpcSharedStateClientHost(rpc).get('k', { initialValue: { count: 1 } })
+    events.emit('rpc:is-trusted:updated', true)
+
+    state.mutate((draft) => {
+      draft.count = 1
+    })
+    expect(setCalls).toHaveLength(0)
+    state.mutate((draft) => {
+      draft.count = 2
+    })
+    expect(setCalls).toHaveLength(1)
+    expect(setCalls[0]?.[1]).toEqual({ count: 2 })
+  })
+
   it('registers the server-sync bridge once across repeated trust flips', async () => {
     const { rpc, events, setCalls } = makeFakeRpc()
     const host = createRpcSharedStateClientHost(rpc)

--- a/packages/devframe/src/in-page-channel/in-page-channel.test.ts
+++ b/packages/devframe/src/in-page-channel/in-page-channel.test.ts
@@ -307,6 +307,45 @@ describe('in-page channel over bring-your-own ports', () => {
 })
 
 describe('in-page channel shared state', () => {
+  it('seeds an equal snapshot and skips unchanged writes on both endpoints', async () => {
+    const { pageScript, panel, dispose } = createLinkedPair()
+    try {
+      const authority = await pageScript.sharedState.get('doc', { initialValue: { count: 1 } })
+      const mirror = await panel.sharedState.get('doc', { initialValue: { count: 1 } })
+      const initialMirror = mirror.value()
+      await until(() => mirror.value() !== initialMirror)
+      expect(mirror.value()).toEqual({ count: 1 })
+
+      const authorityUpdated = vi.fn()
+      const mirrorUpdated = vi.fn()
+      authority.on('updated', authorityUpdated)
+      mirror.on('updated', mirrorUpdated)
+      authority.mutate((draft) => {
+        draft.count = 1
+      })
+      mirror.mutate((draft) => {
+        draft.count = 1
+      })
+      await panel.call('echo', 'flushed')
+      expect(authorityUpdated).not.toHaveBeenCalled()
+      expect(mirrorUpdated).not.toHaveBeenCalled()
+
+      authority.mutate((draft) => {
+        draft.count = 2
+      })
+      await until(() => mirror.value().count === 2)
+      mirror.mutate((draft) => {
+        draft.count = 3
+      })
+      await until(() => authority.value().count === 3)
+      expect(authorityUpdated).toHaveBeenCalledTimes(2)
+      expect(mirrorUpdated).toHaveBeenCalledTimes(2)
+    }
+    finally {
+      dispose()
+    }
+  })
+
   it('replays the authority snapshot and streams patches to panels', async () => {
     const { pageScript, panel, dispose } = createLinkedPair()
     try {

--- a/packages/devframe/src/node/__tests__/rpc-shared-state.test.ts
+++ b/packages/devframe/src/node/__tests__/rpc-shared-state.test.ts
@@ -1,0 +1,32 @@
+import type { DevframeNodeContext } from 'devframe/types'
+import { describe, expect, it, vi } from 'vitest'
+import { RpcFunctionsHostImpl } from '../host-functions'
+
+describe('node-side shared state', () => {
+  it('broadcasts the first RPC snapshot and deduplicates later echoes', async () => {
+    const rpc = new RpcFunctionsHostImpl({} as DevframeNodeContext)
+    const broadcast = vi.spyOn(rpc, 'broadcast').mockResolvedValue()
+
+    await rpc.invokeLocal('devframe:rpc:server-state:set', 'counter', { count: 1 }, 'first')
+    expect(broadcast).toHaveBeenCalledTimes(1)
+    expect(broadcast).toHaveBeenLastCalledWith({
+      method: 'devframe:rpc:client-state:updated',
+      args: ['counter', { count: 1 }, 'first'],
+      filter: expect.any(Function),
+    })
+
+    const state = await rpc.sharedState.get<{ count: number }>('counter')
+    await rpc.invokeLocal('devframe:rpc:server-state:set', 'counter', { count: 2 }, 'first')
+    expect(state.value()).toEqual({ count: 1 })
+    expect(broadcast).toHaveBeenCalledTimes(1)
+
+    await rpc.invokeLocal('devframe:rpc:server-state:set', 'counter', { count: 2 }, 'second')
+    expect(state.value()).toEqual({ count: 2 })
+    expect(broadcast).toHaveBeenCalledTimes(2)
+
+    state.mutate((draft) => {
+      draft.count = 2
+    })
+    expect(broadcast).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/devframe/src/node/rpc-shared-state.ts
+++ b/packages/devframe/src/node/rpc-shared-state.ts
@@ -130,7 +130,8 @@ export function createRpcSharedStateServerHost(
       const state = await host.get(key, {
         initialValue: value,
       })
-      state.mutate(() => value, syncId)
+      // Publish the snapshot even when get() just created the state with this value.
+      state.patch([{ op: 'replace', path: [], value }], syncId)
     },
   })
 

--- a/packages/devframe/src/utils/shared-state.test.ts
+++ b/packages/devframe/src/utils/shared-state.test.ts
@@ -3,6 +3,40 @@ import { describe, expect, it, vi } from 'vitest'
 import { createSharedState } from './shared-state'
 
 describe('shared-state', () => {
+  it.each([false, true])('skips unchanged recipes and keeps sync IDs with patches enabled: %s', (enablePatches) => {
+    const initialValue = { count: 0 }
+    const state = createSharedState({ initialValue, enablePatches })
+    const updated = vi.fn()
+    state.on('updated', updated)
+
+    state.mutate(() => {}, 'empty')
+    state.mutate((draft) => {
+      draft.count = 0
+    }, 'same-value')
+    state.mutate(() => initialValue, 'same-reference')
+    expect(state.value()).toBe(initialValue)
+    expect(updated).not.toHaveBeenCalled()
+    expect([...state.syncIds]).toEqual(['empty', 'same-value', 'same-reference'])
+
+    state.mutate((draft) => {
+      draft.count = 99
+    }, 'same-value')
+    expect(state.value().count).toBe(0)
+    state.mutate((draft) => {
+      draft.count = 1
+    }, 'changed')
+    expect(state.value().count).toBe(1)
+    expect(updated).toHaveBeenCalledTimes(1)
+
+    state.mutate(() => ({ count: 1 }), 'replacement')
+    expect(updated).toHaveBeenCalledTimes(2)
+    expect(() => state.mutate(() => {
+      throw new Error('recipe failed')
+    })).toThrow('recipe failed')
+    expect(state.value().count).toBe(1)
+    expect(updated).toHaveBeenCalledTimes(2)
+  })
+
   describe('immutability', () => {
     it('should return immutable state from get()', () => {
       const state = createSharedState({

--- a/packages/devframe/src/utils/shared-state.ts
+++ b/packages/devframe/src/utils/shared-state.ts
@@ -126,11 +126,16 @@ export function createSharedState<T extends object>(
           state as Objectish,
           fn as (draft: any) => void,
         )
+        if (nextState === state)
+          return
         state = nextState as T
         events.emit('updated', state, patches as SharedStatePatch[], syncId)
       }
       else {
-        state = produce(state as Objectish, fn as (draft: any) => void) as T
+        const nextState = produce(state as Objectish, fn as (draft: any) => void) as T
+        if (nextState === state)
+          return
+        state = nextState
         events.emit('updated', state, undefined, syncId)
       }
     },


### PR DESCRIPTION
Same-value mutations emit `updated` and forward redundant shared-state messages. Skip notification when Immer returns the current state reference, with patches enabled or disabled.

```diff
 mutate(recipe, syncId)
   remember syncId
   next = produce(state, recipe)
+  if next === state: return
   emit updated
```

The repro sets `count` to its current value 1,000 times. Before the fix, this fires 1,000 `updated` events. After the fix, it fires none. Both patch modes give the same result.

Changed writes and distinct replacement objects still notify. Sync IDs stay recorded for unchanged recipes. Apply incoming RPC snapshots as root patches so the first write to a missing key still broadcasts.

| | Description | StackBlitz | GitHub |
| --- | --- | --- | --- |
| Before | 1,000 unchanged writes fire 1,000 `updated` events. | [Run](https://stackblitz.com/github/onmax/repros/tree/repro%2Fdevframe-unchanged-state/devframe-unchanged-state?startScript=verify&file=verify.mjs&terminal=true) | [Source](https://github.com/onmax/repros/tree/repro/devframe-unchanged-state/devframe-unchanged-state) |
| After | The same writes fire no `updated` events. | [Run](https://stackblitz.com/github/onmax/repros/tree/repro%2Fdevframe-unchanged-state/devframe-unchanged-state-fix?startScript=verify&file=verify.mjs&terminal=true) | [Source](https://github.com/onmax/repros/tree/repro/devframe-unchanged-state/devframe-unchanged-state-fix) |

StackBlitz installs dependencies and runs `verify` automatically.

<details>
<summary>Copy and run with Node 24.19.0 and Corepack</summary>

```sh
git clone --depth 1 --filter=blob:none --sparse --branch repro/devframe-unchanged-state https://github.com/onmax/repros.git state-repro
cd state-repro
git sparse-checkout set devframe-unchanged-state devframe-unchanged-state-fix
(cd devframe-unchanged-state && corepack pnpm install --frozen-lockfile --ignore-scripts && corepack pnpm verify)
(cd devframe-unchanged-state-fix && corepack pnpm install --frozen-lockfile --ignore-scripts && corepack pnpm verify)
```

</details>
