### PR TITLE
test(hub-ui): cover collapsed edge logo positions

### DIFF
--- a/packages/hub-ui/src/client/components/dock/DockEdge.stories.ts
+++ b/packages/hub-ui/src/client/components/dock/DockEdge.stories.ts
@@ -72,27 +72,37 @@ export const Right: Story = edgeStory('right')
 /** Toolbar only, nothing selected, so the panel body is collapsed away. */
 export const ToolbarOnly: Story = edgeStory('bottom', false)
 
+function collapsedEdgeStory(position: 'top' | 'right' | 'bottom' | 'left'): Story {
+  return {
+    render: () => ({
+      setup: () => mountWithContext(
+        {
+          entries: categorizedEntries,
+          selectedId: null,
+          panel: { mode: 'edge', position, inactiveTimeout: 0 },
+          session: { open: false },
+        },
+        ctx => [
+          h(DockEdge, { context: ctx }, { view: ({ entry }: any) => body(entry) }),
+          h(FloatingElements),
+        ],
+      ),
+    }),
+  }
+}
+
 /**
  * Idle-collapsed: the default `autoCollapseEdgeToolbar` with `inactiveTimeout:
  * 0` (the same trick `Dock.stories.ts`'s own `Minimized` story uses) shrinks
  * the toolbar down to a small corner pill immediately, with nothing selected.
  */
-export const CollapsedIdle: Story = {
-  render: () => ({
-    setup: () => mountWithContext(
-      {
-        entries: categorizedEntries,
-        selectedId: null,
-        panel: { mode: 'edge', position: 'bottom', inactiveTimeout: 0 },
-        session: { open: false },
-      },
-      ctx => [
-        h(DockEdge, { context: ctx }, { view: ({ entry }: any) => body(entry) }),
-        h(FloatingElements),
-      ],
-    ),
-  }),
-}
+export const CollapsedIdle: Story = collapsedEdgeStory('bottom')
+
+/** Left edge collapsed to its idle logo pill. */
+export const CollapsedLeft: Story = collapsedEdgeStory('left')
+
+/** Right edge collapsed to its idle logo pill. */
+export const CollapsedRight: Story = collapsedEdgeStory('right')
 
 const settingsEntry: DevframeViewBuiltin = {
   type: '~builtin',


### PR DESCRIPTION
## Background (Why)

Collapsed edge docks need explicit visual fixtures for both vertical positions. The logo orientation fix is already on `main` in `0.9.12`, but the existing Storybook coverage only exercised the bottom edge.

## Changes (What)

Add `CollapsedLeft` and `CollapsedRight` stories through a shared collapsed-edge story helper. The existing bottom fixture remains available as `CollapsedIdle`, and the floating `Minimized` story continues to cover the upright floating logo.

## Verification (Testing)

ESLint and the `@devframes/hub-ui` typecheck pass. The Storybook production build completes and includes both new stories. Matched browser checks against the parent of the logo fix show the left and right logo wrapper changing from a 270-degree transform to no transform; the floating minimized logo remains upright.
