### PR TITLE
docs: keep guides first in docs search

### DIFF
--- a/docs/app/components/UContentSearch.vue
+++ b/docs/app/components/UContentSearch.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import ContentSearch from '@nuxt/ui/components/content/ContentSearch.vue'
+
+defineOptions({ inheritAttrs: false })
+</script>
+
+<template>
+  <ContentSearch
+    v-bind="$attrs"
+    preserve-group-order
+  />
+</template>


### PR DESCRIPTION
Keeps docs search groups in navigation order so guides appear before errors and references.

current:

<img width="1586" height="938" alt="@posva-Microsoft Edge‒Build a devtool once  Mount it anywhere -2026-09-07-17 45 02@2x" src="https://github.com/user-attachments/assets/7377d18e-de0c-4033-aee0-c1e99c4a9b12" />

new:

<img width="1580" height="968" alt="@posva-Microsoft Edge‒Build a devtool once  Mount it anywhere -2026-09-07-17 44 57@2x" src="https://github.com/user-attachments/assets/ef222201-7de7-4e80-bb6f-1b65f0af9eeb" />
