### PR TITLE
fix(hub-ui): select a visible dock on standalone startup

### DIFF
--- a/packages/hub-ui/src/client/components/dock/DockStandalone.vue
+++ b/packages/hub-ui/src/client/components/dock/DockStandalone.vue
@@ -29,10 +29,16 @@ const isRpcTrusted = useIsRpcTrusted(context, (isTrusted) => {
   }
 })
 
+/** Select from the visible dock rail through normal activation, including client scripts and group routing. */
 watch(
-  () => context.docks.entries,
-  () => {
-    context.docks.selectedId ||= context.docks.entries[0]?.id ?? null
+  [() => context.docks.groupedEntries, isRpcTrusted],
+  ([groups, trusted]) => {
+    if (!trusted || context.docks.selectedId)
+      return
+    const entry = groups.flatMap(([, entries]) => entries)
+      .find(entry => entry.type !== 'action' && entry.type !== '~builtin')
+    if (entry)
+      void context.docks.switchEntry(entry.id)
   },
   { immediate: true },
 )


### PR DESCRIPTION
## Background (Why)

Standalone startup selects the first raw dock entry, even when that entry has `when: 'false'`. 

A hidden wrapper registered before its visible tools therefore opens an unintended iframe and leaves the content area blank. Clicking a visible dock works. This reproduces on `main` at `5f6d5bee`, after #364.

## Changes (What)

Choose the initial dock from the visible, ordered dock rail once the RPC connection is trusted. 

Use normal `switchEntry()` activation so client scripts and group routing run. 

Preserve existing selections, skip actions and built-in fallbacks, and wait when no eligible dock has arrived.

