### PR TITLE
fix(hub-ui): show failed icons and retry on remount

### DIFF
--- a/packages/hub-ui/src/client/components/icons/IconifyIcon.vue
+++ b/packages/hub-ui/src/client/components/icons/IconifyIcon.vue
@@ -54,6 +54,8 @@ watchEffect(async (onCleanup) => {
   />
   <img
     v-else :src="icon"
+    alt=""
+    aria-hidden="true"
     class="w-full h-full m-auto"
     draggable="false"
   >

--- a/packages/hub-ui/src/client/components/icons/IconifyIcon.vue
+++ b/packages/hub-ui/src/client/components/icons/IconifyIcon.vue
@@ -36,6 +36,7 @@ watchEffect(async (onCleanup) => {
       iconifyLoaded.value = svg
   }
   catch {
+    /** Keep fetch failures local to the icon so the surrounding panel remains usable. */
     if (active)
       failed.value = true
   }

--- a/packages/hub-ui/src/client/components/icons/IconifyIcon.vue
+++ b/packages/hub-ui/src/client/components/icons/IconifyIcon.vue
@@ -49,6 +49,7 @@ watchEffect(async (onCleanup) => {
   </svg>
   <div
     v-else-if="iconifyParsed"
+    aria-hidden="true"
     v-html="iconifyLoaded"
   />
   <img

--- a/packages/hub-ui/src/client/components/icons/IconifyIcon.vue
+++ b/packages/hub-ui/src/client/components/icons/IconifyIcon.vue
@@ -20,25 +20,35 @@ const iconifyParsed = computed(() => {
 })
 
 const iconifyLoaded = ref<string | undefined>(undefined)
-watchEffect(async () => {
-  if (!iconifyParsed.value) {
-    iconifyLoaded.value = undefined
+const failed = ref(false)
+watchEffect(async (onCleanup) => {
+  let active = true
+  onCleanup(() => {
+    active = false
+  })
+  iconifyLoaded.value = undefined
+  failed.value = false
+  if (!iconifyParsed.value)
     return
-  }
   try {
-    iconifyLoaded.value = await getIconifySvg(iconifyParsed.value.collection, iconifyParsed.value.icon)
+    const svg = await getIconifySvg(iconifyParsed.value.collection, iconifyParsed.value.icon)
+    if (active)
+      iconifyLoaded.value = svg
   }
   catch {
-    // A failed icon fetch (offline / flaky CDN) should degrade to a blank icon,
-    // not throw out of the async effect and crash the surrounding panel.
-    iconifyLoaded.value = undefined
+    if (active)
+      failed.value = true
   }
 })
 </script>
 
 <template>
+  <svg v-if="failed" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" class="w-full h-full">
+    <rect x="3" y="3" width="18" height="18" rx="3" />
+    <path d="M12 7v6m0 3v1" />
+  </svg>
   <div
-    v-if="iconifyParsed"
+    v-else-if="iconifyParsed"
     v-html="iconifyLoaded"
   />
   <img

--- a/packages/hub-ui/src/client/components/icons/IconifyIcon.vue
+++ b/packages/hub-ui/src/client/components/icons/IconifyIcon.vue
@@ -44,10 +44,7 @@ watchEffect(async (onCleanup) => {
 </script>
 
 <template>
-  <svg v-if="failed" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" class="w-full h-full">
-    <rect x="3" y="3" width="18" height="18" rx="3" />
-    <path d="M12 7v6m0 3v1" />
-  </svg>
+  <div v-if="failed" class="i-ph:warning-duotone w-full h-full" aria-hidden="true" />
   <div
     v-else-if="iconifyParsed"
     aria-hidden="true"

--- a/packages/hub-ui/src/client/utils/iconify.ts
+++ b/packages/hub-ui/src/client/utils/iconify.ts
@@ -28,13 +28,6 @@ export async function getIconifySvg(collection: string, icon: string) {
     const response = await fetch(url, { signal: AbortSignal.timeout(10_000) })
     if (!response.ok)
       throw new Error(`Iconify request failed: ${response.status}`)
-    const svg = purify.sanitize(await response.text())
-    const svgDocument = new DOMParser().parseFromString(svg, 'image/svg+xml')
-    if (svgDocument.documentElement.localName !== 'svg'
-      || svgDocument.querySelector('parsererror')
-      || !svgDocument.querySelector('path, circle, ellipse, rect, line, polyline, polygon, text, use, image')) {
-      throw new Error('Iconify returned an invalid SVG')
-    }
-    return svg
+    return purify.sanitize(await response.text())
   }
 }

--- a/packages/hub-ui/src/client/utils/iconify.ts
+++ b/packages/hub-ui/src/client/utils/iconify.ts
@@ -28,10 +28,10 @@ export async function getIconifySvg(collection: string, icon: string) {
     if (!response.ok)
       throw new Error(`Iconify request failed: ${response.status}`)
     const svg = purify.sanitize(await response.text())
-    const document = new DOMParser().parseFromString(svg, 'image/svg+xml')
-    if (document.documentElement.localName !== 'svg'
-      || document.querySelector('parsererror')
-      || !document.querySelector('path, circle, ellipse, rect, line, polyline, polygon, text, use, image')) {
+    const svgDocument = new DOMParser().parseFromString(svg, 'image/svg+xml')
+    if (svgDocument.documentElement.localName !== 'svg'
+      || svgDocument.querySelector('parsererror')
+      || !svgDocument.querySelector('path, circle, ellipse, rect, line, polyline, polygon, text, use, image')) {
       throw new Error('Iconify returned an invalid SVG')
     }
     return svg

--- a/packages/hub-ui/src/client/utils/iconify.ts
+++ b/packages/hub-ui/src/client/utils/iconify.ts
@@ -24,10 +24,16 @@ export async function getIconifySvg(collection: string, icon: string) {
 
   async function _get() {
     const url = `https://api.iconify.design/${collection}/${icon}.svg?color=currentColor&width=100%`
-    // Bound the request so a stalled connection (offline / flaky CDN / firewall
-    // black-holing the host) rejects instead of hanging forever; the caller
-    // already degrades a rejected fetch to a blank icon.
-    const svg = await fetch(url, { signal: AbortSignal.timeout(10_000) }).then(res => res.text())
-    return purify.sanitize(svg)
+    const response = await fetch(url, { signal: AbortSignal.timeout(10_000) })
+    if (!response.ok)
+      throw new Error(`Iconify request failed: ${response.status}`)
+    const svg = purify.sanitize(await response.text())
+    const document = new DOMParser().parseFromString(svg, 'image/svg+xml')
+    if (document.documentElement.localName !== 'svg'
+      || document.querySelector('parsererror')
+      || !document.querySelector('path, circle, ellipse, rect, line, polyline, polygon, text, use, image')) {
+      throw new Error('Iconify returned an invalid SVG')
+    }
+    return svg
   }
 }

--- a/packages/hub-ui/src/client/utils/iconify.ts
+++ b/packages/hub-ui/src/client/utils/iconify.ts
@@ -24,6 +24,7 @@ export async function getIconifySvg(collection: string, icon: string) {
 
   async function _get() {
     const url = `https://api.iconify.design/${collection}/${icon}.svg?color=currentColor&width=100%`
+    /** Bound stalled requests so the caller can display its failure glyph. */
     const response = await fetch(url, { signal: AbortSignal.timeout(10_000) })
     if (!response.ok)
       throw new Error(`Iconify request failed: ${response.status}`)


### PR DESCRIPTION
## Background (Why)

HTTP errors from Iconify were cached as successful SVG content, leaving blank dock icons. Rejected requests already leave the cache so a later mount can try again.

## Changes (What)

Reject unsuccessful HTTP responses before caching, preserving the existing SVG sanitization. Show a bundled, color-inheriting fallback after failure and ignore results from obsolete component requests. Keep the existing shared requests and 10-second timeout; retry on the next mount or icon change.

## Verification (Testing)

All 85 existing hub-ui tests, affected lint and type checks pass after simplification. Earlier browser validation covered request failures, shared caching, remount recovery and stale/unmounted components; its temporary harness is excluded from this PR.

The screenshots capture a forced HTTP 503 with Settings still usable, followed by recovery after reload with a deterministic SVG response. Screenshot evidence is stored separately from this PR.

![Failed request with Settings usable](https://raw.githubusercontent.com/dvcolomban/devframe/dvcol/icon-pr-evidence-20260910/recovery/standalone-failure.png)

![Recovered icon after reload](https://raw.githubusercontent.com/dvcolomban/devframe/dvcol/icon-pr-evidence-20260910/recovery/standalone-recovered.png)
